### PR TITLE
feat: WebView에서 http 연결 허용

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -51,6 +51,9 @@ class iBoxFactory: ProjectFactory {
                 "CFBundleTypeRole": "Editor"
             ]
         ],
+        "NSAppTransportSecurity": [
+            "NSAllowsArbitraryLoadsInWebContent": true
+        ]
     ]
     
     private let shareExtensionInfoPlist: [String: Plist.Value] = [


### PR DESCRIPTION
### 📌 개요
- WebView에서 http 연결을 허용했습니다.

### 💻 작업 내용
- info.plist에 다음과 같은 내용을 추가했습니다.
```
"NSAppTransportSecurity": [
    "NSAllowsArbitraryLoadsInWebContent": true
]
```

### 🖼️ 스크린샷
|Hane 접속 가능|
|---|
|<img width="250" alt="Screenshot 2024-03-19 at 12 58 26 PM" src="https://github.com/42Box/iOS/assets/116897060/5787b71c-829f-4876-be24-202b6921697f">|
