### PR TITLE
feat: reset data

### DIFF
--- a/iBox/Sources/AppDelegate.swift
+++ b/iBox/Sources/AppDelegate.swift
@@ -26,8 +26,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     private func preloadFavoriteWeb() {
-        let favorite = UserDefaultsManager.favorite
-        let favoriteUrl = favorite.url
+        let favoriteId = UserDefaultsManager.favoriteId
+        var favoriteUrl: URL? = nil
+        if let favoriteId {
+            favoriteUrl = CoreDataManager.shared.getBookmarkUrl(favoriteId)
+            if favoriteUrl == nil {
+                UserDefaultsManager.favoriteId = nil
+            }
+        }
         WebViewPreloader.shared.preloadFavoriteView(url: favoriteUrl)
     }
 

--- a/iBox/Sources/BoxList/BoxListView.swift
+++ b/iBox/Sources/BoxList/BoxListView.swift
@@ -52,10 +52,15 @@ class BoxListView: UIView {
         setupLayout()
         configureDataSource()
         bindViewModel()
+        subscribeToNotifications()
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
     
     // MARK: - Setup Methods
@@ -139,6 +144,14 @@ class BoxListView: UIView {
                     self?.boxListDataSource.apply(snapshot)
                 }
             }.store(in: &cancellables)
+    }
+    
+    private func subscribeToNotifications() {
+        NotificationCenter.default.addObserver(self, selector: #selector(dataDidReset), name: .didResetData, object: nil)
+    }
+    
+    @objc func dataDidReset(notification: NSNotification) {
+        viewModel?.input.send(.viewDidLoad)
     }
     
 }

--- a/iBox/Sources/BoxList/BoxListView.swift
+++ b/iBox/Sources/BoxList/BoxListView.swift
@@ -190,12 +190,16 @@ extension BoxListView: UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         // 액션 정의
-        let favoriteAction = UIContextualAction(style: .normal, title: "favorite", handler: {(action, view, completionHandler) in
-            self.viewModel?.input.send(.setFavorite(indexPath: indexPath))
+        let favoriteAction = UIContextualAction(style: .normal, title: "favorite", handler: { [weak self] (action, view, completionHandler) in
+            self?.viewModel?.input.send(.toggleFavorite(indexPath: indexPath))
             completionHandler(true)
         })
         favoriteAction.backgroundColor = .box2
-        favoriteAction.image = UIImage(systemName: "heart")
+        if viewModel?.isFavoriteBookmark(at: indexPath) == true {
+            favoriteAction.image = UIImage(systemName: "heart.fill")
+        } else {
+            favoriteAction.image = UIImage(systemName: "heart")
+        }
         
         let shareAction = UIContextualAction(style: .normal, title: "share", handler: {(action, view, completionHandler) in
             let cellViewModel = self.viewModel?.viewModel(at: indexPath)

--- a/iBox/Sources/BoxList/BoxListViewController.swift
+++ b/iBox/Sources/BoxList/BoxListViewController.swift
@@ -84,6 +84,7 @@ extension BoxListViewController: BoxListViewDelegate {
             guard let newName = controller.textFields?.first?.text else { return }
             guard let newUrlString = controller.textFields?.last?.text,
             let newUrl = URL(string: newUrlString) else { return }
+            guard let contentView = self?.contentView as? BoxListView else { return }
             
             contentView.viewModel?.editBookmark(at: indexPath, name: newName, url: newUrl)
         }

--- a/iBox/Sources/Shared/CoreDataManager.swift
+++ b/iBox/Sources/Shared/CoreDataManager.swift
@@ -199,6 +199,15 @@ extension CoreDataManager {
 // 북마크 관련
 extension CoreDataManager {
     
+    func getBookmarkUrl(_ bookmarkId: UUID) -> URL? {
+        let entity = getBookmarkEntity(id: bookmarkId)
+        if let entity {
+            return entity.url
+        } else {
+            return nil
+        }
+    }
+    
     func addBookmark(_ bookmark: Bookmark, folderId: UUID) {
         let context = persistentContainer.viewContext
         

--- a/iBox/Sources/Shared/UserDefaultsManager.swift
+++ b/iBox/Sources/Shared/UserDefaultsManager.swift
@@ -12,8 +12,8 @@ final class UserDefaultsManager {
     @UserDefaultsData(key: "theme", defaultValue: Theme.system)
     static var theme: Theme
     
-    @UserDefaultsData(key: "favorite", defaultValue: Bookmark(id: UUID(), name: "42 Intra", url: URL(string: "https://profile.intra.42.fr/")!))
-    static var favorite: Bookmark
+    @UserDefaultsData(key: "favoriteId", defaultValue: nil)
+    static var favoriteId: UUID?
     
     @UserDefaultsData(key: "homeTabIndex", defaultValue: 0)
     static var homeTabIndex: Int
@@ -23,7 +23,6 @@ final class UserDefaultsManager {
     
     @UserDefaultsData(key: "isPreload", defaultValue: false)
     static var isPreload: Bool
-
 }
 
 @propertyWrapper

--- a/iBox/Sources/Shared/WebViewPreloader.swift
+++ b/iBox/Sources/Shared/WebViewPreloader.swift
@@ -49,7 +49,8 @@ class WebViewPreloader {
     
     func setFavoriteUrl(url: URL?) {
         if let favoriteView {
-            if url == favoriteView.url {
+            if url == favoriteView.url || 
+                (url == nil && favoriteView.url == defaultUrl ) {
                 return
             } else {
                 self.favoriteView?.url = url ?? defaultUrl

--- a/iBox/Sources/Shared/WebViewPreloader.swift
+++ b/iBox/Sources/Shared/WebViewPreloader.swift
@@ -12,6 +12,7 @@ class WebViewPreloader {
     static let shared = WebViewPreloader()
     private var webView: WKWebView?
     private var favoriteView: (url: URL, webView: WKWebView)?
+    private var defaultUrl = URL(string: "https://profile.intra.42.fr/")!
     
     private init() {}
     
@@ -22,11 +23,11 @@ class WebViewPreloader {
         self.webView = webView
     }
     
-    func preloadFavoriteView(url: URL) {
+    func preloadFavoriteView(url: URL?) {
         let webView = WKWebView()
         webView.isOpaque = false
-        webView.load(URLRequest(url: url))
-        favoriteView = (url, webView)
+        webView.load(URLRequest(url: url ?? defaultUrl))
+        favoriteView = (url ?? defaultUrl, webView)
     }
     
     func getWebView() -> WKWebView? {
@@ -44,6 +45,19 @@ class WebViewPreloader {
     func resetFavoriteView() {
         guard let favoriteView else { return }
         favoriteView.webView.load(URLRequest(url: favoriteView.url))
+    }
+    
+    func setFavoriteUrl(url: URL?) {
+        if let favoriteView {
+            if url == favoriteView.url {
+                return
+            } else {
+                self.favoriteView?.url = url ?? defaultUrl
+                resetFavoriteView()
+            }
+        } else {
+            preloadFavoriteView(url: url)
+        }
     }
 
 }


### PR DESCRIPTION
### 📌 개요
- 데이터 초기화 시 코어데이터 초기화 적용 

### 💻 작업 내용
- notification center 이용해 BoxListVIew에 데이터 초기화 알림
- 알림시 BoxListView에서 코어데이터에서 데이터 다시 가져옴
- "iBox" 정확히 쳤을 때만 초기화 확인 버튼 활성화 

### 🖼️ 스크린샷
||
|---|
|![Simulator Screen Recording - iPhone 15 Pro - 2024-03-28 at 14 47 43](https://github.com/42Box/iOS/assets/86519350/b0dcb0a4-e6e7-4dd7-8ae1-a1e3752f33e2)|
