### PR TITLE
fix: 클로저 내부에서 cell을 약한 참조로 캡쳐하여 메모리 누수 해결

### DIFF
--- a/iBox/Sources/AppDelegate.swift
+++ b/iBox/Sources/AppDelegate.swift
@@ -14,8 +14,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 
-        Task {
-            preloadFavoriteWeb()
+        Task { [weak self] in
+            self?.preloadFavoriteWeb()
         }
 
         versioningHandler.checkAppVersion { result in

--- a/iBox/Sources/BoxList/BoxListView.swift
+++ b/iBox/Sources/BoxList/BoxListView.swift
@@ -94,14 +94,14 @@ class BoxListView: UIView {
             guard let cell = tableView.dequeueReusableCell(withIdentifier: BoxListCell.reuseIdentifier, for: indexPath) as? BoxListCell else { fatalError() }
             cell.setEditButtonHidden(!viewModel.isEditing)
             cell.bindViewModel(viewModel.viewModel(at: indexPath))
-            cell.onDelete = { [weak self] in
-                guard let self else { return }
+            cell.onDelete = { [weak self, weak cell] in
+                guard let self = self, let cell = cell else { return }
                 if let currentIndexPath = self.tableView.indexPath(for: cell) {
                     self.viewModel?.deleteBookmark(at: currentIndexPath)
                 }
             }
-            cell.onEdit = { [weak self] in
-                guard let self else { return }
+            cell.onEdit = { [weak self, weak cell] in
+                guard let self = self, let cell = cell else { return }
                 if let currentIndexPath = self.tableView.indexPath(for: cell) {
                     self.delegate?.presentEditBookmarkController(at: currentIndexPath)
                 }

--- a/iBox/Sources/BoxList/BoxListViewController.swift
+++ b/iBox/Sources/BoxList/BoxListViewController.swift
@@ -80,7 +80,7 @@ extension BoxListViewController: BoxListViewDelegate {
         let controller = UIAlertController(title: "북마크 편집", message: nil, preferredStyle: .alert)
         
         let cancelAction = UIAlertAction(title: "취소", style: .default) { _ in return }
-        let okAction = UIAlertAction(title: "확인", style: .default) { [weak self] action in
+        let okAction = UIAlertAction(title: "확인", style: .default) { action in
             guard let newName = controller.textFields?.first?.text else { return }
             guard let newUrlString = controller.textFields?.last?.text,
             let newUrl = URL(string: newUrlString) else { return }

--- a/iBox/Sources/BoxList/EditFolder/EditFolderCell.swift
+++ b/iBox/Sources/BoxList/EditFolder/EditFolderCell.swift
@@ -22,7 +22,7 @@ class EditFolderCell: UITableViewCell {
         $0.showsMenuAsPrimaryAction = true
     }
     
-    private lazy var nameEditAction = UIAction(title: "이름 변경", image: UIImage(systemName: "pencil")) {[weak self] _ in
+    private lazy var nameEditAction = UIAction(title: "이름 변경", image: UIImage(systemName: "pencil")) { [weak self] _ in
         self?.onEdit?()
     }
     
@@ -40,6 +40,11 @@ class EditFolderCell: UITableViewCell {
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func prepareForReuse() {
+        onEdit = nil
+        onDelete = nil
     }
     
     private func setupProperty() {

--- a/iBox/Sources/BoxList/EditFolder/EditFolderView.swift
+++ b/iBox/Sources/BoxList/EditFolder/EditFolderView.swift
@@ -90,14 +90,14 @@ extension EditFolderView: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let viewModel else { fatalError() }
         guard let cell = tableView.dequeueReusableCell(withIdentifier: EditFolderCell.reuserIdentifier, for: indexPath) as? EditFolderCell else { fatalError() }
-        cell.onDelete = { [weak self] in
-            guard let self else { return }
+        cell.onDelete = { [weak self, weak cell] in
+            guard let self = self, let cell = cell else { return }
             if let currentIndexPath = self.tableView.indexPath(for: cell) {
                 self.delegate?.deleteFolder(at: currentIndexPath)
             }
         }
-        cell.onEdit = { [weak self] in
-            guard let self else { return }
+        cell.onEdit = { [weak self, weak cell] in
+            guard let self = self, let cell = cell else { return }
             if let currentIndexPath = self.tableView.indexPath(for: cell) {
                 self.editFolderName(at: currentIndexPath)
             }


### PR DESCRIPTION
### 📌 개요
- Instruments를 통해 발견한 메모리 누수를 해결합니다.

### 💻 작업 내용
- BoxListCell, EditFolderCell의 onEdit, onDelete 클로저를 설정해주는 부분에서 cell에 대해 약한 참조를 캡쳐하도록 수정했습니다.
    ```
    cell.onDelete = { [weak self, weak cell] in
        guard let self = self, let cell = cell else { return }
        if let currentIndexPath = self.tableView.indexPath(for: cell) {
            self.delegate?.deleteFolder(at: currentIndexPath)
        }
    }
    cell.onEdit = { [weak self, weak cell] in
        guard let self = self, let cell = cell else { return }
        if let currentIndexPath = self.tableView.indexPath(for: cell) {
            self.editFolderName(at: currentIndexPath)
        }
    }
    ```

Instruments에서 메모리 누수가 나지 않는 모습 !
<img width="1680" alt="Screenshot 2024-03-28 at 5 36 22 PM" src="https://github.com/42Box/iOS/assets/116897060/1afa4df6-f2a1-4940-8a90-08fcef786855">

