### PR TITLE
fix: move folder error

### DIFF
--- a/iBox/Sources/BoxList/BoxListView.swift
+++ b/iBox/Sources/BoxList/BoxListView.swift
@@ -137,7 +137,7 @@ class BoxListView: UIView {
                 case .reloadSections(idArray: let idArray):
                     guard var snapshot = self?.boxListDataSource.snapshot() else { return }
                     snapshot.reloadSections(idArray)
-                    self?.boxListDataSource.apply(snapshot)
+                    self?.boxListDataSource.apply(snapshot, animatingDifferences: false)
                 case .reloadRows(idArray: let idArray):
                     guard var snapshot = self?.boxListDataSource.snapshot() else { return }
                     snapshot.reloadItems(idArray)

--- a/iBox/Sources/BoxList/BoxListViewModel.swift
+++ b/iBox/Sources/BoxList/BoxListViewModel.swift
@@ -160,6 +160,9 @@ class BoxListViewModel {
     func moveFolder(from: Int, to: Int) {
         let mover = boxList.remove(at: from)
         boxList.insert(mover, at: to)
+        for box in boxList {
+            sectionsToReload.update(with: box.id)
+        }
     }
 
 }


### PR DESCRIPTION
### 📌 개요
- 폴더 이동 후 폴더 터치 이벤트 오류 수정

### 💻 작업 내용
- 폴더 이동 시 전체 section reload

### 🖼️ 스크린샷
||
|---|
|![Simulator Screen Recording - iPhone 15 Pro - 2024-03-28 at 22 35 07](https://github.com/42Box/iOS/assets/86519350/804b8f81-4f15-483e-9741-eac6c5aaf7c3)|


