### PR TITLE
feat: set folder,bookmark name label trailing

### DIFF
--- a/iBox/Sources/BoxList/AddBookmark/AddBookmarkView.swift
+++ b/iBox/Sources/BoxList/AddBookmark/AddBookmarkView.swift
@@ -174,11 +174,11 @@ class AddBookmarkView: UIView {
         buttonLabel.snp.makeConstraints { make in
             make.leading.equalTo(button.snp.leading).offset(20)
             make.centerY.equalTo(button.snp.centerY)
-            make.width.equalTo(40)
             make.height.equalTo(40)
         }
         
         selectedFolderLabel.snp.makeConstraints { make in
+            make.leading.equalTo(buttonLabel.snp.trailing).offset(10)
             make.trailing.equalTo(chevronImageView.snp.leading).offset(-10)
             make.centerY.equalTo(button.snp.centerY)
             make.height.equalTo(40)

--- a/iBox/Sources/BoxList/AddBookmark/FolderListCell.swift
+++ b/iBox/Sources/BoxList/AddBookmark/FolderListCell.swift
@@ -65,19 +65,19 @@ class FolderListCell: UITableViewCell {
             make.bottom.lessThanOrEqualToSuperview().offset(-10)
         }
         
-        folderNameLabel.snp.makeConstraints { make in
-            make.centerY.equalToSuperview()
-            make.leading.equalTo(folderImageView.snp.trailing).offset(10)
-            make.trailing.lessThanOrEqualToSuperview().offset(-20)
-            make.top.greaterThanOrEqualToSuperview().offset(10)
-            make.bottom.lessThanOrEqualToSuperview().offset(-10)
-        }
-        
         checkImageView.snp.makeConstraints { make in
              make.centerY.equalToSuperview()
              make.trailing.equalToSuperview().offset(-20)
              make.width.height.equalTo(24)
          }
+        
+        folderNameLabel.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.leading.equalTo(folderImageView.snp.trailing).offset(10)
+            make.trailing.equalTo(checkImageView.snp.leading).offset(-10)
+            make.top.greaterThanOrEqualToSuperview().offset(10)
+            make.bottom.lessThanOrEqualToSuperview().offset(-10)
+        }
     }
     
     func configureWith(folder: Folder, isSelected: Bool) {

--- a/iBox/Sources/BoxList/BoxListCell.swift
+++ b/iBox/Sources/BoxList/BoxListCell.swift
@@ -85,11 +85,14 @@ class BoxListCell: UITableViewCell {
         }
         
         label.snp.makeConstraints { make in
-            make.top.trailing.bottom.equalToSuperview()
+            make.top.bottom.equalToSuperview()
+            make.trailing.equalToSuperview().inset(25)
             make.leading.equalTo(cellImageView.snp.trailing).offset(10)
         }
         editButton.snp.makeConstraints { make in
-            make.top.bottom.trailing.equalToSuperview()
+            make.width.equalTo(30)
+            make.top.bottom.equalToSuperview()
+            make.trailing.equalToSuperview().offset(-10)
         }
     }
     
@@ -106,6 +109,20 @@ class BoxListCell: UITableViewCell {
     
     func setEditButtonHidden(_ isHidden: Bool) {
         editButton.isHidden = isHidden
+        
+        if isHidden {
+            label.snp.remakeConstraints { make in
+                make.top.bottom.equalToSuperview()
+                make.trailing.equalToSuperview().inset(25)
+                make.leading.equalTo(cellImageView.snp.trailing).offset(10)
+            }
+        } else {
+            label.snp.remakeConstraints { make in
+                make.top.bottom.equalToSuperview()
+                make.trailing.equalTo(editButton.snp.leading).offset(-5)
+                make.leading.equalTo(cellImageView.snp.trailing).offset(10)
+            }
+        }
     }
 
 }

--- a/iBox/Sources/BoxList/BoxListView.swift
+++ b/iBox/Sources/BoxList/BoxListView.swift
@@ -166,7 +166,7 @@ extension BoxListView: UITableViewDelegate {
             make.top.bottom.equalToSuperview()
             make.leading.trailing.equalToSuperview().inset(15)
         }
-        view.backgroundColor = .backgroundColor
+        view.backgroundColor = .tableViewBackgroundColor
         line.backgroundColor = .quaternaryLabel
         return view
     }

--- a/iBox/Sources/BoxList/EditFolder/EditFolderCell.swift
+++ b/iBox/Sources/BoxList/EditFolder/EditFolderCell.swift
@@ -67,7 +67,7 @@ class EditFolderCell: UITableViewCell {
         
         editButton.snp.makeConstraints { make in
             make.top.bottom.equalToSuperview()
-            make.trailing.equalToSuperview().inset(10)
+            make.trailing.equalToSuperview().offset(-10)
             make.width.equalTo(30)
         }
         

--- a/iBox/Sources/BoxList/EditFolder/EditFolderCell.swift
+++ b/iBox/Sources/BoxList/EditFolder/EditFolderCell.swift
@@ -13,6 +13,8 @@ class EditFolderCell: UITableViewCell {
     var onDelete: (() -> Void)?
     var onEdit: (() -> Void)?
     
+    private let containerView = UIView()
+    
     private let folderView = FolderView()
     
     private let editButton = UIButton().then{
@@ -53,16 +55,25 @@ class EditFolderCell: UITableViewCell {
     }
     
     private func setupHierarchy() {
-        contentView.addSubview(folderView)
-        folderView.addSubview(editButton)
+        contentView.addSubview(containerView)
+        containerView.addSubview(folderView)
+        containerView.addSubview(editButton)
     }
     
     private func setupLayout() {
-        folderView.snp.makeConstraints { make in
+        containerView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
         }
+        
         editButton.snp.makeConstraints { make in
-            make.top.bottom.trailing.equalToSuperview()
+            make.top.bottom.equalToSuperview()
+            make.trailing.equalToSuperview().inset(10)
+            make.width.equalTo(30)
+        }
+        
+        folderView.snp.makeConstraints { make in
+            make.top.bottom.leading.equalToSuperview()
+            make.trailing.equalTo(editButton.snp.leading)
         }
     }
     

--- a/iBox/Sources/BoxList/FolderButton.swift
+++ b/iBox/Sources/BoxList/FolderButton.swift
@@ -50,13 +50,15 @@ class FolderButton: UIButton {
     }
     
     private func setupLayout() {
-        folderView.snp.makeConstraints { make in
-            make.edges.equalToSuperview()
-        }
-        
         openCloseImageView.snp.makeConstraints { make in
             make.centerY.equalToSuperview()
+            make.width.height.equalTo(20)
             make.trailing.equalToSuperview().offset(-20)
+        }
+        
+        folderView.snp.makeConstraints { make in
+            make.top.bottom.leading.equalToSuperview()
+            make.trailing.equalTo(openCloseImageView.snp.leading)
         }
     }
     

--- a/iBox/Sources/BoxList/FolderView.swift
+++ b/iBox/Sources/BoxList/FolderView.swift
@@ -51,6 +51,7 @@ class FolderView: UIView {
         folderNameLabel.snp.makeConstraints { make in
             make.centerY.equalToSuperview()
             make.leading.equalTo(folderImageView.snp.trailing).offset(10)
+            make.trailing.equalToSuperview().inset(10)
         }
     }
     


### PR DESCRIPTION
### 📌 개요
- 폴더, 북마크 이름 라벨의 leading, trailing을 설정하여 셀을 넘어가지 않도록 하였습니다. 

### 💻 작업 내용
- 폴더 이름 오토레이아웃 변경 (FolderView, FolderButton, EditFolderCell)
- 북마크 이름 오토레이아웃 변경 (BoxListCell)
- 북마크 추가화면에서 폴더이름 오토레이아웃 변경 (AddBookmarkView, FolderListCell)

### 🖼️ 스크린샷
||
|---|
|![edit_layout](https://github.com/42Box/iOS/assets/86519350/1bcda6a6-d2ae-4bee-92b3-f7efa52b6248)|

