### PR TITLE
feat: set responder in AddBookmarkView/#156

### DIFF
--- a/iBox/Sources/BoxList/AddBookmark/AddBookmarkView.swift
+++ b/iBox/Sources/BoxList/AddBookmark/AddBookmarkView.swift
@@ -228,6 +228,22 @@ class AddBookmarkView: UIView {
 }
 
 extension AddBookmarkView: UITextViewDelegate {
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        let textLength: Int = textView.text.count
+        textView.selectedRange = NSRange(location: textLength, length: 0)
+    }
+    
+    func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        if text == "\n" {
+            if textView == nameTextView {
+                urlTextView.becomeFirstResponder()
+            } else if textView == urlTextView {
+                textView.resignFirstResponder()
+            }
+            return false
+        }
+        return true
+    }
     
     func textViewDidChange(_ textView: UITextView) {
         

--- a/iBox/Sources/BoxList/AddBookmark/AddBookmarkView.swift
+++ b/iBox/Sources/BoxList/AddBookmark/AddBookmarkView.swift
@@ -41,6 +41,7 @@ class AddBookmarkView: UIView {
         $0.font = .cellTitleFont
         $0.textColor = .label
         $0.isScrollEnabled = true
+        $0.keyboardType = .emailAddress
     }
     
     private let separatorView = UIView().then {
@@ -60,6 +61,7 @@ class AddBookmarkView: UIView {
         $0.font = .cellTitleFont
         $0.textColor = .label
         $0.isScrollEnabled = true
+        $0.keyboardType = .emailAddress
     }
     
     private let button = UIButton(type: .custom).then {

--- a/iBox/Sources/BoxList/AddBookmark/AddBookmarkView.swift
+++ b/iBox/Sources/BoxList/AddBookmark/AddBookmarkView.swift
@@ -42,6 +42,7 @@ class AddBookmarkView: UIView {
         $0.textColor = .label
         $0.isScrollEnabled = true
         $0.keyboardType = .emailAddress
+        $0.autocorrectionType = .no
     }
     
     private let separatorView = UIView().then {
@@ -62,6 +63,7 @@ class AddBookmarkView: UIView {
         $0.textColor = .label
         $0.isScrollEnabled = true
         $0.keyboardType = .emailAddress
+        $0.autocorrectionType = .no
     }
     
     private let button = UIButton(type: .custom).then {

--- a/iBox/Sources/BoxList/AddBookmark/AddBookmarkView.swift
+++ b/iBox/Sources/BoxList/AddBookmark/AddBookmarkView.swift
@@ -130,7 +130,7 @@ class AddBookmarkView: UIView {
     private func setupLayout() {
         
         textFieldView.snp.makeConstraints { make in
-            make.top.equalToSuperview().offset(100)
+            make.top.equalToSuperview().offset(70)
             make.height.equalTo(150)
             make.leading.equalToSuperview().offset(20)
             make.trailing.equalToSuperview().offset(-20)

--- a/iBox/Sources/BoxList/AddBookmark/AddBookmarkView.swift
+++ b/iBox/Sources/BoxList/AddBookmark/AddBookmarkView.swift
@@ -176,7 +176,6 @@ class AddBookmarkView: UIView {
         buttonLabel.snp.makeConstraints { make in
             make.leading.equalTo(button.snp.leading).offset(20)
             make.centerY.equalTo(button.snp.centerY)
-            make.width.equalTo(40)
             make.height.equalTo(40)
         }
         
@@ -184,6 +183,7 @@ class AddBookmarkView: UIView {
             make.trailing.equalTo(chevronImageView.snp.leading).offset(-10)
             make.centerY.equalTo(button.snp.centerY)
             make.height.equalTo(40)
+            make.width.equalTo(100)
         }
         
         chevronImageView.snp.makeConstraints { make in

--- a/iBox/Sources/BoxList/AddBookmark/FolderListCell.swift
+++ b/iBox/Sources/BoxList/AddBookmark/FolderListCell.swift
@@ -68,7 +68,7 @@ class FolderListCell: UITableViewCell {
         folderNameLabel.snp.makeConstraints { make in
             make.centerY.equalToSuperview()
             make.leading.equalTo(folderImageView.snp.trailing).offset(10)
-            make.trailing.lessThanOrEqualToSuperview().offset(-20)
+            make.trailing.lessThanOrEqualToSuperview().offset(-60)
             make.top.greaterThanOrEqualToSuperview().offset(10)
             make.bottom.lessThanOrEqualToSuperview().offset(-10)
         }


### PR DESCRIPTION
### 📌 개요
- AddBookmarkView 내 responder 설정 및 리팩토링

### 💻 작업 내용
- 북마크 추가화면 내 textView의 키보드 타입을 emailAddress 타입으로 변경했습니다.
- 북마크 추가화면 내 '목록' 버튼 label 의 width 제약을 삭제 및 선택된 폴더 label 제약을 재설정 했습니다.
- 북마크 추가화면 내 FolderListView의 FolderListCell에서 folderNameLabel 제약을 수정했습니다.
- 북마크 추가화면 내 textField 의 top 제약을 수정했습니다.
- 북마크 추가화면 내 키보드 responder 설정 및 자동보정을 비활성화 했습니다. 

### 🖼️ 스크린샷
- 선택된 폴더 label 제약 수정 이전
![선택된 폴더 label 제약 수정 이전](https://github.com/42Box/iOS/assets/116494364/b9a4d026-00dc-4166-82ba-4576187a3754)


- 선택된 폴더 label 제약 수정 이후
![선택된 폴더 label 제약 수정 이후 ](https://github.com/42Box/iOS/assets/116494364/bf9e1c61-1301-4d5a-846d-7151aad704d9)


- FolderListCell의  folderNameLabel 제약 수정 이전
![FolderListCell의  folderNameLabel 제약 수정 이전](https://github.com/42Box/iOS/assets/116494364/6c800c82-2003-47ef-98ca-44ecf7e1dde8)



- FolderListCell의  folderNameLabel 제약 수정 이후
![FolderListCell의  folderNameLabel 제약 수정 이후](https://github.com/42Box/iOS/assets/116494364/06a95280-4452-44a5-ad3b-cc726521c0a3)


- textField 의 top 제약을 수정 이전
![textField 의 top 제약을 수정 이전](https://github.com/42Box/iOS/assets/116494364/19e5d5f9-49c6-46c5-954e-a4c6ce8571a3)



- textField 의 top 제약을 수정 이후
![textField 의 top 제약을 수정 이후](https://github.com/42Box/iOS/assets/116494364/db825a13-282b-488b-8a7f-484044901d02)

- 자동보정 비활성화 이전

https://github.com/42Box/iOS/assets/116494364/a3acf918-7c13-4a27-8e16-522540633d12

- 자동보정 비활성화 이후

https://github.com/42Box/iOS/assets/116494364/1d1eff33-d203-46d2-a8d1-212af3b0a65e


- 키보드 responder 설정

https://github.com/42Box/iOS/assets/116494364/18e3cd55-3234-47b8-96ac-d85080587ed2

