### PR TITLE
feat: add custom refresh control

### DIFF
--- a/iBox/Sources/BoxList/BoxListViewController.swift
+++ b/iBox/Sources/BoxList/BoxListViewController.swift
@@ -151,6 +151,7 @@ extension BoxListViewController: BoxListViewDelegate {
         } else {
             // 캐시에 없는 경우, 새로운 viewController 인스턴스를 생성하고 캐시에 추가합니다.
             let viewController = WebViewController()
+            viewController.delegate = self
             viewController.selectedWebsite = url
             viewController.title = name
             WebCacheManager.shared.cacheData(forKey: id, viewController: viewController)

--- a/iBox/Sources/Extension/UIColor+Extension.swift
+++ b/iBox/Sources/Extension/UIColor+Extension.swift
@@ -32,7 +32,7 @@ extension UIColor {
     static let box = UIColor(hex: 0xFF7F29)
     static let box2 = UIColor(hex: 0xFF9548)
     static let box3 = UIColor(hex: 0xFFDC6E)
-    static let tableViewBackgroundColor = color(light: .systemGroupedBackground, dark: .systemGray5)
+    static let tableViewBackgroundColor = color(light: .systemGroupedBackground, dark: .systemGray4)
     static let folderGray = color(light: .systemGray3, dark: .systemGray2)
     static let webIconColor = color(light: .black, dark: .systemGray)
     static let dimmedViewColor = UIColor.black.withAlphaComponent(0.75)

--- a/iBox/Sources/Extension/UIFont+Extension.swift
+++ b/iBox/Sources/Extension/UIFont+Extension.swift
@@ -17,5 +17,6 @@ extension UIFont {
     static let cellTitleFont = UIFont.systemFont(ofSize: 16.0)
     static let cellDescriptionFont = UIFont.systemFont(ofSize: 13.0, weight: .regular)
     static let descriptionFont = UIFont.systemFont(ofSize: 14.0)
+    static let refreshControlFont = UIFont.boldSystemFont(ofSize: 12.0)
     
 }

--- a/iBox/Sources/Web/RefreshControl.swift
+++ b/iBox/Sources/Web/RefreshControl.swift
@@ -1,0 +1,32 @@
+//
+//  RefreshControl.swift
+//  iBox
+//
+//  Created by jiyeon on 4/4/24.
+//
+
+import UIKit
+
+class RefreshControl: UIView {
+    
+    // MARK: - UI Components
+    
+    
+    
+    // MARK: - Initializer
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupProperty()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupProperty() {
+        backgroundColor = .systemBlue
+        isUserInteractionEnabled = true
+    }
+    
+}

--- a/iBox/Sources/Web/RefreshControl.swift
+++ b/iBox/Sources/Web/RefreshControl.swift
@@ -7,10 +7,58 @@
 
 import UIKit
 
+import SnapKit
+
+enum RefreshControlType {
+    case addBookmark
+    case refresh
+    case back
+}
+
 class RefreshControl: UIView {
+    
+    var currentType: RefreshControlType?
     
     // MARK: - UI Components
     
+    let addBookmarkButton = UIButton().then {
+        $0.configuration = .plain()
+        $0.tintColor = .label
+        $0.configuration?.image = UIImage(systemName: "bookmark.circle")
+        $0.configuration?.imagePadding = 10
+        $0.configuration?.imagePlacement = .top
+        $0.configuration?.preferredSymbolConfigurationForImage = .init(pointSize: 20.0)
+        $0.configuration?.attributedTitle = AttributedString("북마크 추가", attributes: AttributeContainer([NSAttributedString.Key.font: UIFont.refreshControlFont]))
+        $0.layer.cornerRadius = 15
+    }
+    
+    let refreshButton = UIButton().then {
+        $0.configuration = .plain()
+        $0.tintColor = .label
+        $0.configuration?.image = UIImage(systemName: "arrow.clockwise.circle")
+        $0.configuration?.imagePadding = 10
+        $0.configuration?.imagePlacement = .top
+        $0.configuration?.preferredSymbolConfigurationForImage = .init(pointSize: 20.0)
+        $0.configuration?.attributedTitle = AttributedString("새로고침", attributes: AttributeContainer([NSAttributedString.Key.font: UIFont.refreshControlFont]))
+        $0.layer.cornerRadius = 15
+    }
+    
+    let backButton = UIButton().then {
+        $0.configuration = .plain()
+        $0.tintColor = .label
+        $0.configuration?.image = UIImage(systemName: "arrowshape.turn.up.backward.circle")
+        $0.configuration?.imagePadding = 10
+        $0.configuration?.imagePlacement = .top
+        $0.configuration?.preferredSymbolConfigurationForImage = .init(pointSize: 20.0)
+        $0.configuration?.attributedTitle = AttributedString("처음으로 이동", attributes: AttributeContainer([NSAttributedString.Key.font: UIFont.refreshControlFont]))
+        $0.layer.cornerRadius = 15
+    }
+    
+    let stackView = UIStackView().then {
+        $0.axis = .horizontal
+        $0.distribution = .fillEqually
+        $0.spacing = 20
+    }
     
     
     // MARK: - Initializer
@@ -18,15 +66,48 @@ class RefreshControl: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupProperty()
+        setupHierarchy()
+        setupLayout()
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
+    // MAKR: - Setup Methods
+    
     private func setupProperty() {
-        backgroundColor = .systemBlue
         isUserInteractionEnabled = true
+    }
+    
+    private func setupHierarchy() {
+        addSubview(stackView)
+        stackView.addArrangedSubview(addBookmarkButton)
+        stackView.addArrangedSubview(refreshButton)
+        stackView.addArrangedSubview(backButton)
+    }
+    
+    private func setupLayout() {
+        stackView.snp.makeConstraints { make in
+            make.edges.equalToSuperview().inset(20)
+        }
+    }
+    
+    func setSelected(_ type: RefreshControlType) {
+        if type == currentType { return }
+        currentType = type
+        clear()
+        switch type {
+        case .addBookmark: addBookmarkButton.backgroundColor = .tableViewBackgroundColor
+        case .refresh: refreshButton.backgroundColor = .tableViewBackgroundColor
+        case .back: backButton.backgroundColor = .tableViewBackgroundColor
+        }
+    }
+    
+    func clear() {
+        [addBookmarkButton, refreshButton, backButton].forEach { button in
+            button.backgroundColor = .clear
+        }
     }
     
 }

--- a/iBox/Sources/Web/RefreshControl.swift
+++ b/iBox/Sources/Web/RefreshControl.swift
@@ -77,6 +77,7 @@ class RefreshControl: UIView {
     // MAKR: - Setup Methods
     
     private func setupProperty() {
+        backgroundColor = .backgroundColor
         isUserInteractionEnabled = true
     }
     

--- a/iBox/Sources/Web/RefreshControl.swift
+++ b/iBox/Sources/Web/RefreshControl.swift
@@ -90,7 +90,7 @@ class RefreshControl: UIView {
     
     private func setupLayout() {
         stackView.snp.makeConstraints { make in
-            make.edges.equalToSuperview().inset(20)
+            make.leading.bottom.trailing.equalToSuperview().inset(20)
         }
     }
     
@@ -102,6 +102,11 @@ class RefreshControl: UIView {
         case .addBookmark: addBookmarkButton.backgroundColor = .tableViewBackgroundColor
         case .refresh: refreshButton.backgroundColor = .tableViewBackgroundColor
         case .back: backButton.backgroundColor = .tableViewBackgroundColor
+        }
+        if UserDefaultsManager.isHaptics {
+            let generator = UIImpactFeedbackGenerator(style: .light)
+            generator.prepare()
+            generator.impactOccurred()
         }
     }
     

--- a/iBox/Sources/Web/WebView.swift
+++ b/iBox/Sources/Web/WebView.swift
@@ -48,7 +48,6 @@ class WebView: UIView {
         setupProperty()
         setupHierarchy()
         setupLayout()
-//        setupRefreshControl()
     }
     
     required init?(coder: NSCoder) {

--- a/iBox/Sources/Web/WebView.swift
+++ b/iBox/Sources/Web/WebView.swift
@@ -12,6 +12,8 @@ import SnapKit
 
 class WebView: UIView {
     
+    var delegate: WebViewDelegate?
+    
     private var progressObserver: NSKeyValueObservation?
     
     var selectedWebsite: URL? {
@@ -20,6 +22,9 @@ class WebView: UIView {
         }
     }
     
+    private var refreshControlHeight: CGFloat = 100.0
+    private var isActive = false
+    
     // MARK: - UI Components
     
     private let webView = WKWebView().then {
@@ -27,8 +32,6 @@ class WebView: UIView {
         $0.scrollView.contentInsetAdjustmentBehavior = .always
     }
     
-    private let refreshControl = UIRefreshControl()
-  
     private let progressView = UIProgressView().then {
         $0.progressViewStyle = .bar
         $0.tintColor = .label
@@ -60,11 +63,21 @@ class WebView: UIView {
     private func setupProperty() {
         backgroundColor = .backgroundColor
         webView.navigationDelegate = self
-        webView.scrollView.refreshControl = refreshControl
-        refreshControl.addTarget(self, action: #selector(handleRefreshControl), for: .valueChanged)
         progressObserver = webView.observe(\.estimatedProgress, options: .new) { [weak self] webView, _ in
             self?.progressView.setProgress(Float(webView.estimatedProgress), animated: true)
         }
+        setupRefreshControl()
+    }
+    
+    private func setupRefreshControl() {
+        // pan gesture
+        let panGestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(handleSwipe))
+        panGestureRecognizer.delegate = self
+        addGestureRecognizer(panGestureRecognizer)
+        // refresh control
+        let refreshControl = RefreshControl(frame: .init(x: 0, y: -refreshControlHeight, width: frame.width, height: refreshControlHeight))
+        webView.scrollView.addSubview(refreshControl)
+        webView.scrollView.delegate = self
     }
     
     private func setupHierarchy() {
@@ -88,10 +101,25 @@ class WebView: UIView {
         webView.allowsBackForwardNavigationGestures = true
     }
     
-    @objc private func handleRefreshControl() {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) { [weak self] in
-            self?.webView.reload()
-            self?.refreshControl.endRefreshing()
+    @objc func handleSwipe(_ gesture: UIPanGestureRecognizer) {
+        guard isActive else { return } // 활성 상태일 때만 처리
+        
+        let translation = gesture.translation(in: self)
+        if gesture.state == .ended { // 사용자의 터치가 끝났을 때
+            if abs(translation.x) > 100 {
+                if translation.x > 0 { // 오른쪽 스와이프 : 처음 북마크로 돌아가기
+                    loadWebsite()
+                } else { // 왼쪽 스와이프 : 현재 링크 북마크 추가
+                    guard let url = webView.url else { return }
+                    delegate?.pushAddBookMarkViewController(url: url)
+                }
+            } else { // 아래 : 새로고침
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+                    self?.webView.reload()
+                }
+            }
+            // 제스처 인식 후 초기화
+            gesture.setTranslation(CGPoint.zero, in: self)
         }
     }
     
@@ -107,4 +135,26 @@ extension WebView: WKNavigationDelegate {
         }
     }
   
+}
+
+extension WebView: UIScrollViewDelegate {
+    
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        let refreshControlHeight: CGFloat = 100.0
+        if scrollView.contentOffset.y < -refreshControlHeight {
+            isActive = true
+        } else {
+            isActive = false
+        }
+    }
+    
+}
+
+extension WebView: UIGestureRecognizerDelegate {
+    
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        // 다른 제스처 인식기와 동시에 인식되도록 허용
+        return true
+    }
+    
 }

--- a/iBox/Sources/Web/WebView.swift
+++ b/iBox/Sources/Web/WebView.swift
@@ -22,7 +22,6 @@ class WebView: UIView {
         }
     }
     
-    private var debounceTimer: Timer?
     private var refreshControlHeight: CGFloat = 120.0
     private var isActive = false
     
@@ -92,8 +91,9 @@ class WebView: UIView {
         panGestureRecognizer.delegate = self // UIGestureRecognizerDelegate
         addGestureRecognizer(panGestureRecognizer)
         // refresh control
-        let refreshControl = RefreshControl(frame: .init(x: 0, y: -refreshControlHeight, width: frame.size.width, height: refreshControlHeight))
+        let refreshControl = RefreshControl(frame: .init(x: 0, y: -frame.size.height, width: frame.size.width, height: frame.size.height))
         webView.scrollView.addSubview(refreshControl)
+        webView.scrollView.backgroundColor = .backgroundColor
         webView.scrollView.delegate = self // UIScrollViewDelegate
         self.refreshControl = refreshControl
     }
@@ -104,17 +104,12 @@ class WebView: UIView {
         webView.allowsBackForwardNavigationGestures = true
     }
     
-    private func debounce(interval: TimeInterval, action: @escaping (() -> Void)) {
-        debounceTimer?.invalidate()
-        debounceTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: false, block: { _ in action() })
-    }
-    
     @objc func handleSwipe(_ gesture: UIPanGestureRecognizer) {
         guard isActive, let refreshControl = refreshControl else { return }
         
         let translation = gesture.translation(in: self)
         if gesture.state == .changed {
-            if abs(translation.x) > refreshControlHeight {
+            if abs(translation.x) > 60.0 {
                 if translation.x > 0 { // 오른쪽 스와이프 : 처음 북마크로 돌아가기
                     refreshControl.setSelected(.back)
                 } else { // 왼쪽 스와이프 : 현재 링크 북마크 추가

--- a/iBox/Sources/Web/WebView.swift
+++ b/iBox/Sources/Web/WebView.swift
@@ -107,19 +107,4 @@ extension WebView: WKNavigationDelegate {
         }
     }
   
-    //    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
-    //            print("웹뷰 로딩 실패: \(error.localizedDescription)")
-    //        }
-    //
-    //    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
-    //        print("웹뷰 프로비저널 네비게이션 실패: \(error.localizedDescription)")
-    //    }
-    //
-    //    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
-    //        if let url = navigationAction.request.url {
-    //            print("웹뷰가 리다이렉트 되는 URL: \(url.absoluteString)")
-    //        }
-    //
-    //        decisionHandler(.allow)
-    //    }
 }

--- a/iBox/Sources/Web/WebViewController.swift
+++ b/iBox/Sources/Web/WebViewController.swift
@@ -7,8 +7,13 @@
 
 import UIKit
 
+protocol WebViewDelegate {
+    func pushAddBookMarkViewController(url: URL)
+}
+
 class WebViewController: BaseViewController<WebView>, BaseViewControllerProtocol {
     
+    var delegate: AddBookmarkViewControllerProtocol?
     var selectedWebsite: URL?
 
     // MARK: - Life Cycle
@@ -20,6 +25,7 @@ class WebViewController: BaseViewController<WebView>, BaseViewControllerProtocol
         view.backgroundColor = .backgroundColor
         
         guard let contentView = contentView as? WebView else { return }
+        contentView.delegate = self
         contentView.selectedWebsite = selectedWebsite
     }
     
@@ -29,4 +35,19 @@ class WebViewController: BaseViewController<WebView>, BaseViewControllerProtocol
         setNavigationBarHidden(true)
     }
 
+}
+
+extension WebViewController: WebViewDelegate {
+    
+    func pushAddBookMarkViewController(url: URL) {
+        URLDataManager.shared.incomingData = url.absoluteString
+        
+        let addBookmarkViewController = AddBookmarkViewController()
+        addBookmarkViewController.delegate = delegate
+        
+        let navigationController = UINavigationController(rootViewController: addBookmarkViewController)
+        navigationController.modalPresentationStyle = .pageSheet
+        self.present(navigationController, animated: true, completion: nil)
+    }
+    
 }

--- a/iBox/Sources/Web/WebViewController.swift
+++ b/iBox/Sources/Web/WebViewController.swift
@@ -29,6 +29,12 @@ class WebViewController: BaseViewController<WebView>, BaseViewControllerProtocol
         contentView.selectedWebsite = selectedWebsite
     }
     
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        guard let contentView = contentView as? WebView else { return }
+        contentView.setupRefreshControl()
+    }
+    
     // MARK: - BaseViewControllerProtocol
     
     func setupNavigationBar() {


### PR DESCRIPTION
### 📌 개요
- 커스텀 리프레시 컨트롤 추가

### 💻 작업 내용
- `북마크 추가`, `새로 고침`, `처음으로 이동`의 3가지 행동을 할 수 있는 커스텀 리프레시 컨트롤을 추가합니다.

### 🖼️ 스크린샷
https://github.com/42Box/iOS/assets/116897060/6d965056-67d0-445d-a0e9-f6d8ea6af7bb

<details><summary>안습 (배경 색상 설정해서 해결 !)</summary>
<p>

|![IMG_7513](https://github.com/42Box/iOS/assets/116897060/5146b94b-c6eb-48a8-990e-08d52837f210)|![IMG_7514](https://github.com/42Box/iOS/assets/116897060/559cb863-afad-47c1-9c19-6c269fdf3f60)|![IMG_7515](https://github.com/42Box/iOS/assets/116897060/3f25c7ac-1737-4e62-b322-4e2058f2bcdb)|
|-|-|-|

</p>
</details>


