### PR TITLE
feat: 웹뷰 내 로딩 추적

### DIFF
--- a/iBox/Sources/Web/WebView.swift
+++ b/iBox/Sources/Web/WebView.swift
@@ -103,12 +103,18 @@ class WebView: UIView {
 
 extension WebView: WKNavigationDelegate {
     
+    func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+        // 로딩 시작 시 프로그레스 바를 보여주고 진행률 초기화
+        progressView.isHidden = false
+        progressView.setProgress(0.0, animated: false)
+    }
+    
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         progressView.setProgress(1.0, animated: true)
-        // 약간의 딜레이를 주어서 프로그레스 바가 완전히 차도록 함
+        // 약간의 딜레이 후 프로그레스 바를 숨김
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             self.progressView.isHidden = true
         }
     }
-  
+    
 }


### PR DESCRIPTION
### 📌 개요
- 웹뷰 내 로딩을 추적합니다.

### 💻 작업 내용
- 기존에는 초기 페이지 로드 시에만 프로그레스 바가 표시되었지만, 이제 웹뷰 내에서 다른 페이지로의 이동 시에도 로딩을 추적하여 보여줍니다.
- 웹 콘텐츠의 로딩 상태에 따라 프로그레스 바의 가시성과 진행 상황을 업데이트하기 위해 추가 WKNavigationDelegate 메소드를 구현했습니다.

### 🖼️ 스크린샷

https://github.com/42Box/iOS/assets/116897060/6d90f055-de1c-40aa-86d4-b2756c3bd51d

