### PR TITLE
fix: Command ValidateEmbeddedBinary failed 문제 해결

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -30,7 +30,7 @@ class iBoxFactory: ProjectFactory {
         "ITSAppUsesNonExemptEncryption": false,
         "CFBundleDisplayName": "iBox",
         "CFBundleName": "iBox",
-        "CFBundleShortVersionString": "1.2.2",
+        "CFBundleShortVersionString": "1.0.0",
         "CFBundleVersion": "1",
         "UILaunchStoryboardName": "LaunchScreen",
         "UIApplicationSceneManifest": [
@@ -58,7 +58,7 @@ class iBoxFactory: ProjectFactory {
     
     private let shareExtensionInfoPlist: [String: Plist.Value] = [
         "CFBundleDisplayName": "iBox.Share",
-        "CFBundleShortVersionString": "1.0",
+        "CFBundleShortVersionString": "1.0.0",
         "CFBundleVersion": "1",
         "NSExtension": [
             "NSExtensionAttributes": [


### PR DESCRIPTION
### 🚨 문제 상황
<img alt="Screenshot 2024-04-09 at 12 30 32 PM" src="https://github.com/42Box/iOS/assets/116897060/3614a6f3-0b9c-4796-9179-566600bd2b99">

### 🔍 원인
부모 앱(iBox)과 앱 확장(ShareExtension)의 번들 버전(`CFBundleShortVersionString`)이 서로 일치하지 않아 발생한 문제입니다. 이로 인해 Xcode가 앱 확장을 부모 앱의 일부로 정확히 인식하지 못하고 있었습니다.

### 💻 작업 내용
- `Project.swift`의 `infoPlist` 부분에서 부모 앱(iBox) 및 앱 확장(ShareExtension)의 `CFBundleShortVersionString` 값을 "**1.0.0**"으로 일치시켰습니다.

