### PR TITLE
feat: 새 창으로 열기 옵션 링크 내부에서 열기

### DIFF
--- a/iBox/Sources/Web/WebView.swift
+++ b/iBox/Sources/Web/WebView.swift
@@ -162,7 +162,15 @@ extension WebView: WKNavigationDelegate {
             self.progressView.isHidden = true
         }
     }
-  
+    
+    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        // "새 창으로 열기" 링크 WebView 내에서 열기
+        if navigationAction.targetFrame == nil {
+            webView.load(navigationAction.request)
+        }
+        decisionHandler(.allow)
+    }
+    
 }
 
 extension WebView: UIScrollViewDelegate {


### PR DESCRIPTION
### 📌 개요
- "새 창으로 열기" 옵션이 설정된 (`target="_blank"`) 링크를 웹뷰 내부에서 열기 위해 WKNavigationDelegate에 함수를 구현했습니다.

### 💻 작업 내용
``` javascript
func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
    // "새 창으로 열기" 링크 WebView 내에서 열기
    if navigationAction.targetFrame == nil {
        webView.load(navigationAction.request)
    }
    decisionHandler(.allow)
}
```
