### PR TITLE
feat: empty folder label

### DIFF
--- a/iBox/Resources/Assets.xcassets/42pack_icon/sitting_fox/sitting_fox0.imageset/Contents.json
+++ b/iBox/Resources/Assets.xcassets/42pack_icon/sitting_fox/sitting_fox0.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/iBox/Resources/Assets.xcassets/42pack_icon/sitting_fox/sitting_fox1.imageset/Contents.json
+++ b/iBox/Resources/Assets.xcassets/42pack_icon/sitting_fox/sitting_fox1.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/iBox/Resources/Assets.xcassets/42pack_icon/sitting_fox/sitting_fox2.imageset/Contents.json
+++ b/iBox/Resources/Assets.xcassets/42pack_icon/sitting_fox/sitting_fox2.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/iBox/Resources/Assets.xcassets/42pack_icon/sitting_fox/sitting_fox3.imageset/Contents.json
+++ b/iBox/Resources/Assets.xcassets/42pack_icon/sitting_fox/sitting_fox3.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/iBox/Sources/BoxList/AddBookmark/AddBookmarkView.swift
+++ b/iBox/Sources/BoxList/AddBookmark/AddBookmarkView.swift
@@ -196,11 +196,10 @@ class AddBookmarkView: UIView {
         }
         
         selectedFolderLabel.snp.makeConstraints { make in
-            make.leading.equalTo(buttonLabel.snp.trailing).offset(10)
             make.trailing.equalTo(chevronImageView.snp.leading).offset(-10)
             make.centerY.equalTo(button.snp.centerY)
             make.height.equalTo(40)
-//            make.width.equalTo(100)
+            make.width.equalTo(200)
         }
         
         chevronImageView.snp.makeConstraints { make in

--- a/iBox/Sources/BoxList/AddBookmark/AddBookmarkView.swift
+++ b/iBox/Sources/BoxList/AddBookmark/AddBookmarkView.swift
@@ -93,9 +93,10 @@ class AddBookmarkView: UIView {
     }
     
     private let chevronImageView = UIImageView().then {
-        let image = UIImage(systemName: "chevron.forward")?.withRenderingMode(.alwaysTemplate)
+        let config = UIImage.SymbolConfiguration(pointSize: 15, weight: .medium, scale: .default)
+        let image = UIImage(systemName: "chevron.forward", withConfiguration: config)?.withRenderingMode(.alwaysTemplate)
         $0.image = image
-        $0.tintColor = .systemGray
+        $0.tintColor = .systemGray3
         $0.contentMode = .scaleAspectFit
     }
     
@@ -199,14 +200,13 @@ class AddBookmarkView: UIView {
             make.trailing.equalTo(chevronImageView.snp.leading).offset(-10)
             make.centerY.equalTo(button.snp.centerY)
             make.height.equalTo(40)
-            make.width.equalTo(100)
+//            make.width.equalTo(100)
         }
         
         chevronImageView.snp.makeConstraints { make in
             make.trailing.equalTo(button.snp.trailing).offset(-20)
             make.centerY.equalTo(button.snp.centerY)
-            make.width.equalTo(17)
-            make.height.equalTo(17)
+            make.width.height.equalTo(15)
         }
         
     }

--- a/iBox/Sources/BoxList/BoxListView.swift
+++ b/iBox/Sources/BoxList/BoxListView.swift
@@ -43,6 +43,32 @@ class BoxListView: UIView {
         $0.rowHeight = 50
     }
     
+    private let emptyStackView = UIStackView().then {
+        $0.axis = .horizontal
+        $0.spacing = 10
+        $0.isHidden = true
+    }
+    
+    private let emptyLabel = UILabel().then {
+        $0.text = "폴더가 없습니다"
+        $0.font = .emptyLabelFont
+        $0.textColor = .secondaryLabel
+        $0.textAlignment = .center
+    }
+    
+    private let emptyImageView = UIImageView().then {
+        let image0 = UIImage(named: "sitting_fox0")?.imageWithColor(.secondaryLabel) ?? UIImage()
+        let image1 = UIImage(named: "sitting_fox1")?.imageWithColor(.secondaryLabel) ?? UIImage()
+        let image2 = UIImage(named: "sitting_fox2")?.imageWithColor(.secondaryLabel) ?? UIImage()
+        let image3 = UIImage(named: "sitting_fox3")?.imageWithColor(.secondaryLabel) ?? UIImage()
+        let images = [image0, image1, image2, image3]
+        $0.contentMode = .scaleAspectFit
+        $0.tintColor = .secondaryLabel
+        $0.animationImages = images
+        $0.animationDuration = 1.5
+        $0.startAnimating()
+    }
+    
     // MARK: - Initializer
     
     override init(frame: CGRect) {
@@ -74,6 +100,7 @@ class BoxListView: UIView {
     private func setupHierarchy() {
         addSubview(backgroundView)
         backgroundView.addSubview(tableView)
+        backgroundView.addSubview(emptyStackView)
     }
     
     private func setupLayout() {
@@ -86,6 +113,18 @@ class BoxListView: UIView {
             make.top.bottom.equalToSuperview().offset(10)
             make.leading.trailing.equalToSuperview()
         }
+        
+        emptyStackView.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+        }
+        
+        emptyImageView.snp.makeConstraints { make in
+            make.width.height.equalTo(30)
+        }
+        
+        emptyStackView.addArrangedSubview(emptyLabel)
+        emptyStackView.addArrangedSubview(emptyImageView)
+        
     }
     
     private func configureDataSource() {
@@ -130,6 +169,7 @@ class BoxListView: UIView {
                 switch event {
                 case .sendBoxList(boxList: let boxList):
                     self?.applySnapshot(with: boxList)
+                    self?.emptyStackView.isHidden = !boxList.isEmpty
                 case .editStatus(isEditing: let isEditing):
                     self?.tableView.setEditing(isEditing, animated: true)
                     guard let snapshot = self?.boxListDataSource.snapshot() else { return }
@@ -150,7 +190,7 @@ class BoxListView: UIView {
         NotificationCenter.default.addObserver(self, selector: #selector(dataDidReset), name: .didResetData, object: nil)
     }
     
-    @objc func dataDidReset(notification: NSNotification) {
+    @objc private func dataDidReset(notification: NSNotification) {
         viewModel?.input.send(.viewDidLoad)
     }
     

--- a/iBox/Sources/BoxList/BoxListViewController.swift
+++ b/iBox/Sources/BoxList/BoxListViewController.swift
@@ -51,8 +51,6 @@ class BoxListViewController: BaseViewController<BoxListView>, BaseViewController
     // MARK: - Action Functions
     
     @objc private func addButtonTapped() {
-        guard let contentView = contentView as? BoxListView else { return }
-        
         let addBookmarkViewController = AddBookmarkViewController()
         addBookmarkViewController.delegate = self
         

--- a/iBox/Sources/BoxList/FolderButton.swift
+++ b/iBox/Sources/BoxList/FolderButton.swift
@@ -53,7 +53,7 @@ class FolderButton: UIButton {
     private func setupLayout() {
         openCloseImageView.snp.makeConstraints { make in
             make.centerY.equalToSuperview()
-            make.width.height.equalTo(20)
+            make.width.height.equalTo(15)
             make.trailing.equalToSuperview().offset(-20)
         }
         

--- a/iBox/Sources/BoxList/FolderButton.swift
+++ b/iBox/Sources/BoxList/FolderButton.swift
@@ -42,7 +42,8 @@ class FolderButton: UIButton {
     
     private func setupProperty() {
         backgroundColor = .tableViewBackgroundColor
-        openCloseImageView.image = UIImage(systemName: "chevron.right")
+        let config = UIImage.SymbolConfiguration(pointSize: 15, weight: .medium, scale: .default)
+        openCloseImageView.image = UIImage(systemName: "chevron.right", withConfiguration: config)
     }
     
     private func setupHierarchy() {

--- a/iBox/Sources/Extension/UIFont+Extension.swift
+++ b/iBox/Sources/Extension/UIFont+Extension.swift
@@ -11,12 +11,12 @@ extension UIFont {
     
     static let titleFont = UIFont.systemFont(ofSize: 20.0, weight: .bold)
     static let subTitlefont = UIFont.systemFont(ofSize: 17.0, weight: .semibold)
-    static let lableFont = UIFont.systemFont(ofSize: 16.0)
+    static let labelFont = UIFont.systemFont(ofSize: 16.0)
     static let semiboldLabelFont = UIFont.systemFont(ofSize: 16.0, weight: .semibold)
     static let boldLabelFont = UIFont.systemFont(ofSize: 16.0, weight: .bold)
     static let cellTitleFont = UIFont.systemFont(ofSize: 16.0)
     static let cellDescriptionFont = UIFont.systemFont(ofSize: 13.0, weight: .regular)
     static let descriptionFont = UIFont.systemFont(ofSize: 14.0)
     static let refreshControlFont = UIFont.boldSystemFont(ofSize: 12.0)
-    
+    static let emptyLabelFont = UIFont.systemFont(ofSize: 17.0, weight: .regular)
 }

--- a/iBox/Sources/Extension/UIImage+Extension.swift
+++ b/iBox/Sources/Extension/UIImage+Extension.swift
@@ -1,0 +1,27 @@
+//
+//  UIImage+Extension.swift
+//  iBox
+//
+//  Created by 이지현 on 4/11/24.
+//
+
+import UIKit
+
+extension UIImage {
+    func imageWithColor(_ color: UIColor) -> UIImage? {
+        UIGraphicsBeginImageContextWithOptions(self.size, false, self.scale);
+        guard let context = UIGraphicsGetCurrentContext(), let cgImage = self.cgImage else { return nil }
+
+        context.translateBy(x: 0, y: self.size.height)
+        context.scaleBy(x: 1.0, y: -1.0);
+        context.setBlendMode(.normal)
+        let rect = CGRect(x: 0, y: 0, width: size.width, height: size.height)
+        context.clip(to: rect, mask: cgImage)
+        color.setFill()
+        context.fill(rect)
+        let  newImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext();
+
+        return newImage
+    }
+}


### PR DESCRIPTION
### 📌 개요
- 폴더가 없을 때 라벨 보여줌
- 폴더 옆 버튼 크기 수정

### 💻 작업 내용
- emptyStackView(emptyLabel, emptyImageView)를 folder 있을 때 isHidden = false
- 폴더버튼 size 수정

### 🖼️ 스크린샷
|emptyStackView|폴더버튼|
|---|---|
|![Simulator Screen Recording - iPhone 15 Pro - 2024-04-11 at 18 14 06](https://github.com/42Box/iOS/assets/86519350/c93c0e46-182e-4fe2-96b9-e93fca5b3411)|![Simulator Screen Recording - iPhone 15 Pro - 2024-04-11 at 18 12 24](https://github.com/42Box/iOS/assets/86519350/aeb6ebaa-fb43-4eef-943e-c84f57b5b43a)|
