### PR TITLE
fix: SettingItemCell chevron 버튼 터치 안 되는 문제 해결

### DIFF
--- a/iBox/Sources/Settings/SettingsItemCell.swift
+++ b/iBox/Sources/Settings/SettingsItemCell.swift
@@ -34,6 +34,7 @@ class SettingsItemCell: UITableViewCell {
         $0.configuration?.image = UIImage(systemName: "chevron.right")
         $0.configuration?.preferredSymbolConfigurationForImage = .init(pointSize: 10, weight: .bold)
         $0.tintColor = .systemGray3
+        $0.isUserInteractionEnabled = false
     }
     
     // MARK: - Initializer


### PR DESCRIPTION
### 📌 개요
- SettingsItemCell의 chevron 버튼 영역이 터치가 안 되는 문제를 해결합니다.

### 💻 작업 내용
- chevron 버튼의 `isUserInteractionEnabled` 속성을 false로 지정합니다.
