### PR TITLE
refactor: nameTextView 및 clearButton 제약 수정

### DIFF
--- a/iBox/Sources/AddBookmark/AddBookmarkView.swift
+++ b/iBox/Sources/AddBookmark/AddBookmarkView.swift
@@ -158,7 +158,7 @@ class AddBookmarkView: UIView {
         nameTextView.snp.makeConstraints { make in
             make.top.equalTo(textFieldView.snp.top).offset(10)
             make.leading.equalTo(textFieldView.snp.leading).offset(15)
-            make.trailing.equalTo(textFieldView.snp.trailing).offset(-15)
+            make.trailing.equalTo(clearButton.snp.leading)
             make.height.equalTo(30)
         }
         
@@ -169,13 +169,14 @@ class AddBookmarkView: UIView {
         
         clearButton.snp.makeConstraints { make in
             make.top.equalTo(nameTextView.snp.top).offset(7)
-            make.trailing.equalTo(nameTextView.snp.trailing).offset(-5)
+            make.trailing.equalTo(textFieldView.snp.trailing).offset(-15)
+            make.width.height.equalTo(24)
         }
         
         separatorView.snp.makeConstraints { make in
             make.top.equalTo(nameTextView.snp.bottom).offset(10)
             make.leading.equalTo(nameTextView.snp.leading).offset(5)
-            make.trailing.equalTo(nameTextView.snp.trailing).offset(-5)
+            make.trailing.equalTo(textFieldView.snp.trailing).offset(-15)
             make.height.equalTo(1)
         }
         


### PR DESCRIPTION
### 📌 개요
- nameTextView 및 clearButton 제약 수정

### 💻 작업 내용
- nameTextView의 text가 clearButton에 겹치지 않도록 제약을 수정했습니다.

### 🖼️ 스크린샷
|||
|---|---|
|||
![제약수정](https://github.com/42Box/iOS/assets/116494364/e4c2cd5d-35b2-46f7-8cbd-e1bf64a2cb9e)

