### PR TITLE
fix: bookmark move error

### DIFF
--- a/iBox/Sources/BoxList/BoxListView.swift
+++ b/iBox/Sources/BoxList/BoxListView.swift
@@ -150,6 +150,7 @@ class BoxListView: UIView {
             
             return cell
         }
+        boxListDataSource.defaultRowAnimation = .top
         boxListDataSource.delegate = self
     }
     
@@ -422,7 +423,6 @@ class BoxListDataSource: UITableViewDiffableDataSource<BoxListSectionViewModel.I
     weak var delegate: BoxListDataSourceDelegate?
     
     override func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
-        
         delegate?.moveCell(at: sourceIndexPath, to: destinationIndexPath)
         
         guard let src = itemIdentifier(for: sourceIndexPath),
@@ -430,7 +430,11 @@ class BoxListDataSource: UITableViewDiffableDataSource<BoxListSectionViewModel.I
         
         var snap = snapshot()
         if let dest = itemIdentifier(for: destinationIndexPath) {
-            snap.moveItem(src, beforeItem:dest)
+            if sourceIndexPath.section == destinationIndexPath.section && sourceIndexPath.row < destinationIndexPath.row {
+                snap.moveItem(src, afterItem: dest)
+            } else {
+                snap.moveItem(src, beforeItem:dest)
+            }
         } else {
             snap.deleteItems([src])
             snap.appendItems([src], toSection: snap.sectionIdentifiers[destinationIndexPath.section])

--- a/iBox/Sources/BoxList/BoxListViewModel.swift
+++ b/iBox/Sources/BoxList/BoxListViewModel.swift
@@ -17,6 +17,7 @@ class BoxListViewModel {
     }
 
     var sectionsToReload = Set<BoxListSectionViewModel.ID>()
+    var rowsToReload = Set<BoxListCellViewModel.ID>()
     var isEditing = false
     var favoriteId: UUID? = nil
 


### PR DESCRIPTION
### 📌 개요
- 북마크 이동시 순서가 바뀌는 오류 수정 

### 💻 작업 내용
- tableView(_:moveRowAt:to:)에서 같은 섹션 내에서 row 아래로 옮길 때 로직 추가

### 🖼️ 스크린샷
|before|after|
|---|---|
|![Simulator Screen Recording - iPhone 15 Pro - 2024-04-16 at 22 25 54](https://github.com/42Box/iOS/assets/86519350/debfb3c4-b6eb-4b52-9839-09a5aabf1c05)|![Simulator Screen Recording - iPhone 15 Pro - 2024-04-16 at 22 26 36](https://github.com/42Box/iOS/assets/86519350/09a6681f-513b-4de8-acb5-bce7b8d94789)|



