### PR TITLE
fix: url encoding decoding 관련 수정

### DIFF
--- a/ShareExtension/Sources/ShareViewController.swift
+++ b/ShareExtension/Sources/ShareViewController.swift
@@ -133,7 +133,7 @@ extension CustomShareViewController: ShareExtensionBackGroundViewDelegate {
             return
         }
         
-        let urlString = "iBox://url?data=\(sharedURL)"
+        let urlString = "iBox://url?data=\(sharedURL)".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
         
         if let openUrl = URL(string: urlString) {
             if self.openURL(openUrl) {
@@ -143,6 +143,7 @@ extension CustomShareViewController: ShareExtensionBackGroundViewDelegate {
             }
         } else {
             print("url error")
+            // 해당 url은 사용할 수 없음을 보여주는 뷰를 만들어야함.
         }
     }
 }

--- a/iBox/Sources/Web/WebViewController.swift
+++ b/iBox/Sources/Web/WebViewController.swift
@@ -48,8 +48,6 @@ extension WebViewController: WebViewDelegate {
     func pushAddBookMarkViewController(url: URL) {
         let encodingURL = url.absoluteString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
         
-//        AddBookmarkManager.shared.incomingData = encodingURL
-        
         if let iBoxUrl = URL(string: "iBox://url?data=" + encodingURL) {
             if let tabBarController = findMainTabBarController() {
                 AddBookmarkManager.shared.navigateToAddBookmarkView(from: iBoxUrl, in: tabBarController)

--- a/iBox/Sources/Web/WebViewController.swift
+++ b/iBox/Sources/Web/WebViewController.swift
@@ -48,7 +48,7 @@ extension WebViewController: WebViewDelegate {
     func pushAddBookMarkViewController(url: URL) {
         let encodingURL = url.absoluteString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
         
-        AddBookmarkManager.shared.incomingData = encodingURL
+//        AddBookmarkManager.shared.incomingData = encodingURL
         
         if let iBoxUrl = URL(string: "iBox://url?data=" + encodingURL) {
             if let tabBarController = findMainTabBarController() {

--- a/iBox/Sources/Web/WebViewController.swift
+++ b/iBox/Sources/Web/WebViewController.swift
@@ -46,9 +46,11 @@ class WebViewController: BaseViewController<WebView>, BaseViewControllerProtocol
 extension WebViewController: WebViewDelegate {
     
     func pushAddBookMarkViewController(url: URL) {
-        AddBookmarkManager.shared.incomingData = url.absoluteString
+        let encodingURL = url.absoluteString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
         
-        if let iBoxUrl = URL(string: "iBox://url?data=" + url.absoluteString) {
+        AddBookmarkManager.shared.incomingData = encodingURL
+        
+        if let iBoxUrl = URL(string: "iBox://url?data=" + encodingURL) {
             if let tabBarController = findMainTabBarController() {
                 AddBookmarkManager.shared.navigateToAddBookmarkView(from: iBoxUrl, in: tabBarController)
             }


### PR DESCRIPTION
### 📌 개요
- URL encoding과 decoding 관련 수정.

### 💻 작업 내용
- 여러 개의 쿼리 파라미터가 있는 url의 경우 첫 번째를 제외한 나머지 쿼리 파라미터가 전달이 안되는 부분을 수정하였습니다.
- ShareExtension시 url에 한글이 들어 있는 경우 북마크 추가 화면에 글자가 깨져서 들어오는 부분을 수정하였습니다.

### 🖼️ 스크린샷
 
https://github.com/42Box/iOS/assets/116494364/7495bb65-7898-4c29-b591-a2c927321838

