### PR TITLE
feat: FolderListViewController에 백 제스처 허용

### DIFF
--- a/iBox/Sources/AddBookmark/AddBookmarkView.swift
+++ b/iBox/Sources/AddBookmark/AddBookmarkView.swift
@@ -248,6 +248,7 @@ class AddBookmarkView: UIView {
     @objc func clearTextView() {
         nameTextView.text = ""
         textViewDidChange(nameTextView)
+        nameTextView.becomeFirstResponder()
     }
     
     @objc private func buttonTapped() {

--- a/iBox/Sources/AddBookmark/AddBookmarkViewController.swift
+++ b/iBox/Sources/AddBookmark/AddBookmarkViewController.swift
@@ -31,13 +31,13 @@ final class AddBookmarkViewController: UIViewController {
         super.viewWillAppear(animated)
         updateSelectedFolder()
         addBookmarkView.updateTextFieldsFilledState()
-        addBookmarkView.nameTextView.becomeFirstResponder()
     }
 
     override func viewDidLoad() {
         super.viewDidLoad()
         setupNavigationBar()
         updateSelectedFolder()
+        addBookmarkView.nameTextView.becomeFirstResponder()
     }
     
     private func setupNavigationBar() {

--- a/iBox/Sources/AddBookmark/FolderListViewController.swift
+++ b/iBox/Sources/AddBookmark/FolderListViewController.swift
@@ -34,6 +34,7 @@ class FolderListViewController: UIViewController {
         super.viewDidLoad()
         
         setupNavigationBar()
+        navigationController?.interactivePopGestureRecognizer?.delegate = self
     }
     
     private func setupNavigationBar() {
@@ -99,4 +100,10 @@ extension FolderListViewController: FolderListViewDelegate {
         self.navigationController?.popViewController(animated: true)
     }
     
+}
+
+extension FolderListViewController: UIGestureRecognizerDelegate {
+  func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+    return true
+  }
 }


### PR DESCRIPTION
### 📌 개요
- FolderListViewController에 제스처를 통한 뒤로 가기를 허용하는 기능을 추가했습니다.

### 💻 작업 내용
``` Swift
navigationController?.interactivePopGestureRecognizer?.delegate = self
```

+clearButton 터치 시 nameTextView를 firstResponder로 설정합니다.

### 🖼️ 스크린샷

https://github.com/42Box/iOS/assets/116897060/6dfd3a26-0dcc-4d76-8466-fb47151e429c

