### PR TITLE
fix: bookmark 편집시 애니메이션 수정

### DIFF
--- a/iBox/Sources/BoxList/BoxListView.swift
+++ b/iBox/Sources/BoxList/BoxListView.swift
@@ -177,7 +177,7 @@ class BoxListView: UIView {
                     self?.applySnapshot(with: boxList)
                     self?.emptyStackView.isHidden = !boxList.isEmpty
                 case .editStatus(isEditing: let isEditing):
-                    self?.tableView.setEditing(isEditing, animated: true)
+                    self?.tableView.setEditing(isEditing, animated: false)
                     guard let snapshot = self?.boxListDataSource.snapshot() else { return }
                     self?.boxListDataSource.applySnapshotUsingReloadData(snapshot)
                 case .reloadSections(idArray: let idArray):


### PR DESCRIPTION
### 📌 개요
- 이름에 이모티콘 있을 때 불필요한 애니메이션

### 💻 작업 내용
- setEditing의 animation 없앰 

### 🖼️ 스크린샷
|before|after|
|---|---|
|![Simulator Screen Recording - iPhone 15 Pro - 2024-04-17 at 15 47 37](https://github.com/42Box/iOS/assets/86519350/2b622fc6-2303-4eea-a0ab-0c4fed5c0596)|![Simulator Screen Recording - iPhone 15 Pro - 2024-04-17 at 15 48 31](https://github.com/42Box/iOS/assets/86519350/d9d540e3-cc06-42b1-b0cf-371a3aa3edb7)|


