### PR TITLE
fix: 폴더 비었을 때 모드에 따른 여우 색 변경

### DIFF
--- a/iBox/Sources/BoxList/BoxListView.swift
+++ b/iBox/Sources/BoxList/BoxListView.swift
@@ -94,6 +94,21 @@ class BoxListView: UIView {
         NotificationCenter.default.removeObserver(self)
     }
     
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if #available(iOS 13.0, *), traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+            let image0 = UIImage(named: "sitting_fox0")?.imageWithColor(.secondaryLabel) ?? UIImage()
+            let image1 = UIImage(named: "sitting_fox1")?.imageWithColor(.secondaryLabel) ?? UIImage()
+            let image2 = UIImage(named: "sitting_fox2")?.imageWithColor(.secondaryLabel) ?? UIImage()
+            let image3 = UIImage(named: "sitting_fox3")?.imageWithColor(.secondaryLabel) ?? UIImage()
+            let images = [image0, image1, image2, image3]
+            emptyImageView.animationImages = images
+            if !emptyStackView.isHidden {
+                emptyImageView.startAnimating()
+            }
+        }
+    }
+    
     // MARK: - Setup Methods
     
     private func setupProperty() {
@@ -176,6 +191,11 @@ class BoxListView: UIView {
                 case .sendBoxList(boxList: let boxList):
                     self?.applySnapshot(with: boxList)
                     self?.emptyStackView.isHidden = !boxList.isEmpty
+                    if self?.emptyStackView.isHidden == false {
+                        self?.emptyImageView.startAnimating()
+                    } else {
+                        self?.emptyImageView.stopAnimating()
+                    }
                 case .editStatus(isEditing: let isEditing):
                     self?.tableView.setEditing(isEditing, animated: false)
                     guard let snapshot = self?.boxListDataSource.snapshot() else { return }

--- a/iBox/Sources/BoxList/BoxListView.swift
+++ b/iBox/Sources/BoxList/BoxListView.swift
@@ -94,20 +94,20 @@ class BoxListView: UIView {
         NotificationCenter.default.removeObserver(self)
     }
     
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        if #available(iOS 13.0, *), traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
-            let image0 = UIImage(named: "sitting_fox0")?.imageWithColor(.secondaryLabel) ?? UIImage()
-            let image1 = UIImage(named: "sitting_fox1")?.imageWithColor(.secondaryLabel) ?? UIImage()
-            let image2 = UIImage(named: "sitting_fox2")?.imageWithColor(.secondaryLabel) ?? UIImage()
-            let image3 = UIImage(named: "sitting_fox3")?.imageWithColor(.secondaryLabel) ?? UIImage()
-            let images = [image0, image1, image2, image3]
-            emptyImageView.animationImages = images
-            if !emptyStackView.isHidden {
-                emptyImageView.startAnimating()
-            }
-        }
-    }
+//    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+//        super.traitCollectionDidChange(previousTraitCollection)
+//        if #available(iOS 13.0, *), traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+//            let image0 = UIImage(named: "sitting_fox0")?.imageWithColor(.secondaryLabel) ?? UIImage()
+//            let image1 = UIImage(named: "sitting_fox1")?.imageWithColor(.secondaryLabel) ?? UIImage()
+//            let image2 = UIImage(named: "sitting_fox2")?.imageWithColor(.secondaryLabel) ?? UIImage()
+//            let image3 = UIImage(named: "sitting_fox3")?.imageWithColor(.secondaryLabel) ?? UIImage()
+//            let images = [image0, image1, image2, image3]
+//            emptyImageView.animationImages = images
+//            if !emptyStackView.isHidden {
+//                emptyImageView.startAnimating()
+//            }
+//        }
+//    }
     
     // MARK: - Setup Methods
     

--- a/iBox/Sources/BoxList/BoxListView.swift
+++ b/iBox/Sources/BoxList/BoxListView.swift
@@ -61,17 +61,24 @@ class BoxListView: UIView {
         $0.textAlignment = .center
     }
     
+    private lazy var lightEmptyImages = [
+        UIImage(named: "sitting_fox0")?.imageWithColor(.secondaryLabel.resolvedColor(with: .init(userInterfaceStyle: .light))) ?? UIImage(),
+        UIImage(named: "sitting_fox1")?.imageWithColor(.secondaryLabel.resolvedColor(with: .init(userInterfaceStyle: .light))) ?? UIImage(),
+        UIImage(named: "sitting_fox2")?.imageWithColor(.secondaryLabel.resolvedColor(with: .init(userInterfaceStyle: .light))) ?? UIImage(),
+        UIImage(named: "sitting_fox3")?.imageWithColor(.secondaryLabel.resolvedColor(with: .init(userInterfaceStyle: .light))) ?? UIImage()
+    ]
+    
+    private lazy var darkEmptyImages = [
+        UIImage(named: "sitting_fox0")?.imageWithColor(.secondaryLabel.resolvedColor(with: .init(userInterfaceStyle: .dark))) ?? UIImage(),
+        UIImage(named: "sitting_fox1")?.imageWithColor(.secondaryLabel.resolvedColor(with: .init(userInterfaceStyle: .dark))) ?? UIImage(),
+        UIImage(named: "sitting_fox2")?.imageWithColor(.secondaryLabel.resolvedColor(with: .init(userInterfaceStyle: .dark))) ?? UIImage(),
+        UIImage(named: "sitting_fox3")?.imageWithColor(.secondaryLabel.resolvedColor(with: .init(userInterfaceStyle: .dark))) ?? UIImage()
+    ]
+    
     private let emptyImageView = UIImageView().then {
-        let image0 = UIImage(named: "sitting_fox0")?.imageWithColor(.secondaryLabel) ?? UIImage()
-        let image1 = UIImage(named: "sitting_fox1")?.imageWithColor(.secondaryLabel) ?? UIImage()
-        let image2 = UIImage(named: "sitting_fox2")?.imageWithColor(.secondaryLabel) ?? UIImage()
-        let image3 = UIImage(named: "sitting_fox3")?.imageWithColor(.secondaryLabel) ?? UIImage()
-        let images = [image0, image1, image2, image3]
         $0.contentMode = .scaleAspectFit
         $0.tintColor = .secondaryLabel
-        $0.animationImages = images
         $0.animationDuration = 1.5
-        $0.startAnimating()
     }
     
     // MARK: - Initializer
@@ -97,12 +104,11 @@ class BoxListView: UIView {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         if #available(iOS 13.0, *), traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
-            let image0 = UIImage(named: "sitting_fox0")?.imageWithColor(.secondaryLabel) ?? UIImage()
-            let image1 = UIImage(named: "sitting_fox1")?.imageWithColor(.secondaryLabel) ?? UIImage()
-            let image2 = UIImage(named: "sitting_fox2")?.imageWithColor(.secondaryLabel) ?? UIImage()
-            let image3 = UIImage(named: "sitting_fox3")?.imageWithColor(.secondaryLabel) ?? UIImage()
-            let images = [image0, image1, image2, image3]
-            emptyImageView.animationImages = images
+            if previousTraitCollection?.userInterfaceStyle == .light {
+                emptyImageView.animationImages = darkEmptyImages
+            } else {
+                emptyImageView.animationImages = lightEmptyImages
+            }
             if !emptyStackView.isHidden {
                 emptyImageView.startAnimating()
             }
@@ -115,6 +121,12 @@ class BoxListView: UIView {
         backgroundColor = .backgroundColor
         viewModel = BoxListViewModel()
         tableView.delegate = self
+        
+        if UITraitCollection.current.userInterfaceStyle == .light {
+            emptyImageView.animationImages = lightEmptyImages
+        } else {
+            emptyImageView.animationImages = darkEmptyImages
+        }
     }
     
     private func setupHierarchy() {

--- a/iBox/Sources/BoxList/BoxListView.swift
+++ b/iBox/Sources/BoxList/BoxListView.swift
@@ -94,20 +94,20 @@ class BoxListView: UIView {
         NotificationCenter.default.removeObserver(self)
     }
     
-//    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-//        super.traitCollectionDidChange(previousTraitCollection)
-//        if #available(iOS 13.0, *), traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
-//            let image0 = UIImage(named: "sitting_fox0")?.imageWithColor(.secondaryLabel) ?? UIImage()
-//            let image1 = UIImage(named: "sitting_fox1")?.imageWithColor(.secondaryLabel) ?? UIImage()
-//            let image2 = UIImage(named: "sitting_fox2")?.imageWithColor(.secondaryLabel) ?? UIImage()
-//            let image3 = UIImage(named: "sitting_fox3")?.imageWithColor(.secondaryLabel) ?? UIImage()
-//            let images = [image0, image1, image2, image3]
-//            emptyImageView.animationImages = images
-//            if !emptyStackView.isHidden {
-//                emptyImageView.startAnimating()
-//            }
-//        }
-//    }
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if #available(iOS 13.0, *), traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+            let image0 = UIImage(named: "sitting_fox0")?.imageWithColor(.secondaryLabel) ?? UIImage()
+            let image1 = UIImage(named: "sitting_fox1")?.imageWithColor(.secondaryLabel) ?? UIImage()
+            let image2 = UIImage(named: "sitting_fox2")?.imageWithColor(.secondaryLabel) ?? UIImage()
+            let image3 = UIImage(named: "sitting_fox3")?.imageWithColor(.secondaryLabel) ?? UIImage()
+            let images = [image0, image1, image2, image3]
+            emptyImageView.animationImages = images
+            if !emptyStackView.isHidden {
+                emptyImageView.startAnimating()
+            }
+        }
+    }
     
     // MARK: - Setup Methods
     


### PR DESCRIPTION
### 📌 개요
- 라이트모드/다크모드에 따른 여우 색깔 적용 

### 💻 작업 내용
- traitCollectionDidChange에서 모드 변경 감지

### 🖼️ 스크린샷
|before|after|
|---|---|
|![Simulator Screen Recording - iPhone 15 Pro - 2024-04-17 at 18 30 58](https://github.com/42Box/iOS/assets/86519350/dcd55516-b837-48ec-bae2-36b4c65a3311)|![Simulator Screen Recording - iPhone 15 Pro - 2024-04-17 at 18 29 47](https://github.com/42Box/iOS/assets/86519350/3152c4ec-ca76-4d93-ac4b-cdc8c0fea57e)
|

