### PR TITLE
fix: ShareExtension시 present 되어 있는 view가 있는 경우 버그 수정

### DIFF
--- a/iBox/Sources/BoxList/BoxListViewController.swift
+++ b/iBox/Sources/BoxList/BoxListViewController.swift
@@ -12,11 +12,10 @@ class BoxListViewController: BaseViewController<BoxListView>, BaseViewController
     var shouldPresentModalAutomatically: Bool = false {
         didSet {
             if shouldPresentModalAutomatically {
-                // shouldPresentModalAutomatically가 true로 설정될 때 함수 호출
-                if findAddBookmarkView() == nil {
+                if findAddBookmarkViewController() == false {
+                    dismiss(animated: false)
                     self.addButtonTapped()
                 }
-                // 함수 호출 후 shouldPresentModalAutomatically를 false로 설정
                 shouldPresentModalAutomatically = false
             }
         }

--- a/iBox/Sources/Extension/UIViewController+Extension.swift
+++ b/iBox/Sources/Extension/UIViewController+Extension.swift
@@ -19,16 +19,11 @@ extension UIViewController {
         return nil
     }
     
-    func findAddBookmarkView() -> Bool? {
-        var responder: UIResponder? = self
-        while let nextResponder = responder?.next {
-            if let viewController = nextResponder as? AddBookmarkView {
-                return true
-            }
-            responder = nextResponder
+    func findAddBookmarkViewController() -> Bool {
+        if let navigationController = presentedViewController as? UINavigationController,
+           let _ = navigationController.topViewController as? AddBookmarkViewController {
+            return true
         }
-        return nil
+        return false
     }
-    
-    
 }


### PR DESCRIPTION
### 📌 개요
- 이미 present된 view가 있는 경우 ShareExtension시 북마크 추가화면이 뜨지 않는 버그 수정.

### 💻 작업 내용
- ShareExtension 시 현재 뷰 컨트롤러가 AddBookmarkViewController이지 않은 경우 현재 모달을 dismiss 후 addButtonTapped() 메서르를 호출합니다. 

### 🖼️ 스크린샷
https://github.com/42Box/iOS/assets/116494364/61d95c58-8ffe-4ad5-b3e5-67e175dbcfb9