### PR TITLE
fix: cell remove animation

### DIFF
--- a/iBox/Sources/BoxList/BoxListView.swift
+++ b/iBox/Sources/BoxList/BoxListView.swift
@@ -377,7 +377,7 @@ extension BoxListView: UITableViewDelegate {
     }
     
     func tableView(_ tableView: UITableView, contextMenuConfigurationForRowAt indexPath: IndexPath, point: CGPoint) -> UIContextMenuConfiguration? {
-        let configuration = UIContextMenuConfiguration(identifier: nil, previewProvider: { [weak self] () -> UIViewController? in
+        let configuration = UIContextMenuConfiguration(identifier: indexPath as NSIndexPath, previewProvider: { [weak self] () -> UIViewController? in
             guard let self = self, let cellViewModel = self.viewModel?.boxList[indexPath.section].boxListCellViewModelsWithStatus[indexPath.row] else { return nil }
             
             let id = cellViewModel.id
@@ -401,6 +401,17 @@ extension BoxListView: UITableViewDelegate {
             return self.makeContextMenu(for: indexPath)
         })
         return configuration
+    }
+    
+    func tableView(_ tableView: UITableView, previewForDismissingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview? {
+        guard let indexPath = configuration.identifier as? IndexPath, let cell = tableView.cellForRow(at: indexPath) else {
+                    return nil
+        }
+        
+        let parameters = UIPreviewParameters()
+        parameters.backgroundColor = .clear
+        
+        return UITargetedPreview(view: cell, parameters: parameters)
     }
     
     private func makeContextMenu(for indexPath: IndexPath) -> UIMenu {


### PR DESCRIPTION
### 📌 개요
- 셀 지웠을 때 애니메이션 오류 수정 

### 💻 작업 내용
- previewForDismissingContextMenuWithConfiguration 에서 background clear로 설정

### 🖼️ 스크린샷
||
|---|
|![Simulator Screen Recording - iPhone 15 Pro - 2024-04-18 at 16 29 42](https://github.com/42Box/iOS/assets/86519350/33cf9b54-15bf-4b92-bdb9-832e1a2cd4cf)|



