### PR TITLE
fix: http url 처리

### DIFF
--- a/iBox/Sources/Shared/AddBookmarkManager.swift
+++ b/iBox/Sources/Shared/AddBookmarkManager.swift
@@ -84,7 +84,10 @@ class AddBookmarkManager {
         if urlString.hasPrefix("http://") {
             update(with: (nil, urlString, nil))
         } else {
-            guard let url = URL(string: urlString) else { return }
+            guard let url = URL(string: urlString) else { 
+                isFetching = false
+                return
+            }
             fetchWebsiteDetails(from: url)
         }
         

--- a/iBox/Sources/Shared/AddBookmarkManager.swift
+++ b/iBox/Sources/Shared/AddBookmarkManager.swift
@@ -74,13 +74,19 @@ class AddBookmarkManager {
     
     func navigateToAddBookmarkView(from url: URL, in tabBarController: UITabBarController) {
         guard url.scheme == "iBox", let urlString = extractDataParameter(from: url) else { return }
-        guard let url = URL(string: urlString) else { return }
         
         incomingTitle = nil
         incomingData = nil
         incomingFaviconUrl = nil
         isFetching = true
-        fetchWebsiteDetails(from: url)
+        
+        
+        if urlString.hasPrefix("http://") {
+            update(with: (nil, urlString, nil))
+        } else {
+            guard let url = URL(string: urlString) else { return }
+            fetchWebsiteDetails(from: url)
+        }
         
         tabBarController.selectedIndex = 0
         


### PR DESCRIPTION
### 📌 개요
- 쉐어익스텐션/북마크 추가에서 http가 들어온 경우 바로 url만 입력되도록 수정

### 💻 작업 내용
- http:// 들어온 경우 따로 처리

### 🖼️ 스크린샷
||
|---|
|![fixHttp](https://github.com/42Box/iOS/assets/86519350/678cd5c1-bd6f-490d-ad01-7242c2a3eb56)|

