### PR TITLE
feat: remove preload

### DIFF
--- a/iBox/Sources/AppDelegate.swift
+++ b/iBox/Sources/AppDelegate.swift
@@ -14,7 +14,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     let versioningHandler: VersioningHandler = VersioningHandler()
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        woraroundInitialWebViewDelay()
+        workaroundInitialWebViewDelay()
 
         versioningHandler.checkAppVersion { result in
             AppStateManager.shared.isVersionCheckCompleted = result
@@ -23,7 +23,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
     
-    func woraroundInitialWebViewDelay() {
+    func workaroundInitialWebViewDelay() {
         let webView = WKWebView()
         webView.loadHTMLString("", baseURL: nil)
     }

--- a/iBox/Sources/AppDelegate.swift
+++ b/iBox/Sources/AppDelegate.swift
@@ -5,20 +5,16 @@
 //  Created by 김찬희 on 2023/12/21.
 //
 
-import UIKit
 import CoreData
+import UIKit
+import WebKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
     let versioningHandler: VersioningHandler = VersioningHandler()
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        
-        if UserDefaultsManager.isPreload {
-            Task { [weak self] in
-                self?.preloadFavoriteWeb()
-            }
-        }
+        woraroundInitialWebViewDelay()
 
         versioningHandler.checkAppVersion { result in
             AppStateManager.shared.isVersionCheckCompleted = result
@@ -27,16 +23,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
     
-    private func preloadFavoriteWeb() {
-        let favoriteId = UserDefaultsManager.favoriteId
-        var favoriteUrl: URL? = nil
-        if let favoriteId {
-            favoriteUrl = CoreDataManager.shared.getBookmarkUrl(favoriteId)
-            if favoriteUrl == nil {
-                UserDefaultsManager.favoriteId = nil
-            }
-        }
-        WebViewPreloader.shared.preloadFavoriteView(url: favoriteUrl)
+    func woraroundInitialWebViewDelay() {
+        let webView = WKWebView()
+        webView.loadHTMLString("", baseURL: nil)
     }
 
     // MARK: UISceneSession Lifecycle

--- a/iBox/Sources/Favorite/FavoriteView.swift
+++ b/iBox/Sources/Favorite/FavoriteView.swift
@@ -12,12 +12,14 @@ import SnapKit
 
 class FavoriteView: UIView {
     
-    lazy var webView = {
-        if WebViewPreloader.shared.getFavoriteView() == nil {
-            loadFavoriteWeb()
-        }
-        return WebViewPreloader.shared.getFavoriteView()
-    }()
+    var webView: WebView?
+    
+//    lazy var webView = {
+//        if WebViewPreloader.shared.getFavoriteView() == nil {
+//            loadFavoriteWeb()
+//        }
+//        return WebViewPreloader.shared.getFavoriteView()
+//    }()
     
     // MARK: - Initializer
     
@@ -41,6 +43,9 @@ class FavoriteView: UIView {
     
     private func setupProperty() {
         backgroundColor = .backgroundColor
+        
+        loadFavoriteWeb()
+        webView = WebViewPreloader.shared.getFavoriteView()
     }
     
     private func setupHierarchy() {

--- a/iBox/Sources/Favorite/FavoriteView.swift
+++ b/iBox/Sources/Favorite/FavoriteView.swift
@@ -14,13 +14,6 @@ class FavoriteView: UIView {
     
     var webView: WebView?
     
-//    lazy var webView = {
-//        if WebViewPreloader.shared.getFavoriteView() == nil {
-//            loadFavoriteWeb()
-//        }
-//        return WebViewPreloader.shared.getFavoriteView()
-//    }()
-    
     // MARK: - Initializer
     
     override init(frame: CGRect) {

--- a/iBox/Sources/Favorite/FavoriteViewController.swift
+++ b/iBox/Sources/Favorite/FavoriteViewController.swift
@@ -20,13 +20,7 @@ class FavoriteViewController: BaseViewController<FavoriteView>, BaseViewControll
         guard let contentView = contentView as? FavoriteView else { return }
         contentView.webView?.delegate = self
     }
-    
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-        guard let contentView = contentView as? FavoriteView else { return }
-        contentView.webView?.setupRefreshControl()
-    }
-    
+     
     // MARK: - BaseViewControllerProtocol
     
     func setupNavigationBar() {

--- a/iBox/Sources/Model/SettingsItem.swift
+++ b/iBox/Sources/Model/SettingsItem.swift
@@ -11,7 +11,6 @@ enum SettingsType {
     case theme
     case homeTab
     case haptics
-    case preload
     case reset
     case guide
     case feedback
@@ -21,7 +20,6 @@ enum SettingsType {
         case .theme: "테마"
         case .homeTab: "홈화면"
         case .haptics: "진동"
-        case .preload: "즐겨찾기 미리 로드"
         case .reset: "데이터 초기화"
         case .guide: "앱 소개"
         case .feedback: "앱 피드백"

--- a/iBox/Sources/Settings/SettingsView.swift
+++ b/iBox/Sources/Settings/SettingsView.swift
@@ -74,11 +74,6 @@ final class SettingsView: UIView {
         viewModel.input.send(.setHaptics(controlSwitch.isOn))
     }
     
-    @objc private func handlePreloadSwitchTap(_ controlSwitch: UISwitch) {
-        guard let viewModel = viewModel else { return }
-        viewModel.input.send(.setPreload(controlSwitch.isOn))
-    }
-    
 }
 
 extension SettingsView: UITableViewDelegate {
@@ -105,7 +100,7 @@ extension SettingsView: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard let viewModel = viewModel else { return }
         let settingsItem = viewModel.sectionViewModels[indexPath.section].cellViewModels[indexPath.row].settingsItem
-        if (settingsItem.type != SettingsType.haptics && settingsItem.type != SettingsType.preload) {
+        if (settingsItem.type != SettingsType.haptics) {
             delegate?.pushViewController(settingsItem.type)
         }
     }
@@ -129,9 +124,6 @@ extension SettingsView: UITableViewDataSource {
         if settingsType == .haptics {
             cell.switchControl.removeTarget(nil, action: nil, for: .valueChanged)
             cell.switchControl.addTarget(self, action: #selector(handleHapticsSwitchTap), for: .valueChanged)
-        } else if settingsType == .preload {
-            cell.switchControl.removeTarget(nil, action: nil, for: .valueChanged)
-            cell.switchControl.addTarget(self, action: #selector(handlePreloadSwitchTap), for: .valueChanged)
         }
         return cell
     }

--- a/iBox/Sources/Settings/SettingsViewModel.swift
+++ b/iBox/Sources/Settings/SettingsViewModel.swift
@@ -13,7 +13,6 @@ class SettingsViewModel {
     enum Input {
         case viewWillAppear
         case setHaptics(_ isOn: Bool)
-        case setPreload(_ isOn: Bool)
     }
     
     enum Output {
@@ -36,8 +35,6 @@ class SettingsViewModel {
                 self?.output.send(.updateSectionViewModels)
             case let .setHaptics(isOn):
                 UserDefaultsManager.isHaptics = isOn
-            case let .setPreload(isOn):
-                UserDefaultsManager.isPreload = isOn
             }
         }.store(in: &cancellables)
         return output.eraseToAnyPublisher()
@@ -47,8 +44,7 @@ class SettingsViewModel {
         sectionViewModels.append(SettingsSectionViewModel(cellViewModels: [
             SettingsCellViewModel(SettingsItem(type: .theme, description: UserDefaultsManager.theme.toString())),
             SettingsCellViewModel(SettingsItem(type: .homeTab, description: HomeTabType.allCases[UserDefaultsManager.homeTabIndex].toString())),
-            SettingsCellViewModel(SettingsItem(type: .haptics, flag: UserDefaultsManager.isHaptics)),
-            SettingsCellViewModel(SettingsItem(type: .preload, flag: UserDefaultsManager.isPreload))
+            SettingsCellViewModel(SettingsItem(type: .haptics, flag: UserDefaultsManager.isHaptics))
         ]))
         sectionViewModels.append(SettingsSectionViewModel(cellViewModels: [
             SettingsCellViewModel(SettingsItem(type: .reset)),

--- a/iBox/Sources/Shared/UserDefaultsManager.swift
+++ b/iBox/Sources/Shared/UserDefaultsManager.swift
@@ -24,9 +24,6 @@ final class UserDefaultsManager {
     @UserDefaultsData(key: "isHaptics", defaultValue: true)
     static var isHaptics: Bool
     
-    @UserDefaultsData(key: "isPreload", defaultValue: false)
-    static var isPreload: Bool
-    
     @UserDefaultsData(key: "selectedFolderId", defaultValue: nil)
     static var selectedFolderId: UUID?
 

--- a/iBox/Sources/Web/RefreshControl.swift
+++ b/iBox/Sources/Web/RefreshControl.swift
@@ -78,7 +78,6 @@ class RefreshControl: UIView {
     
     private func setupProperty() {
         backgroundColor = .backgroundColor
-        translatesAutoresizingMaskIntoConstraints = false 
         isUserInteractionEnabled = true
     }
     

--- a/iBox/Sources/Web/RefreshControl.swift
+++ b/iBox/Sources/Web/RefreshControl.swift
@@ -78,6 +78,7 @@ class RefreshControl: UIView {
     
     private func setupProperty() {
         backgroundColor = .backgroundColor
+        translatesAutoresizingMaskIntoConstraints = false 
         isUserInteractionEnabled = true
     }
     


### PR DESCRIPTION
### 📌 개요
- 즐겨찾기 미리로드 없앰
- webview 로딩 지연 없앰

### 💻 작업 내용
- setting에서 preload 삭제 
- appdelegate에서 webview 로드해서 처음 로드할 때 지연 해결 (https://stackoverflow.com/questions/74301868/wkwebview-ios-slow-on-first-launch)

### 🖼️ 스크린샷
||
|---|
|<img width=300 src="https://github.com/42Box/iOS/assets/86519350/4bff04e0-4d47-44a6-9622-5abc7eb66ee7">|

