### PR TITLE
fix: 북마크 추가 시 url 안에 있는 # 그대로 처리

### DIFF
--- a/iBox/Sources/AddBookmark/AddBookmarkViewController.swift
+++ b/iBox/Sources/AddBookmark/AddBookmarkViewController.swift
@@ -175,7 +175,10 @@ final class AddBookmarkViewController: UIViewController {
             urlString = "https://" + urlString
         }
         
-        guard let encodedUrlString = urlString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+        var allowedCharacters = CharacterSet.urlQueryAllowed
+        allowedCharacters.insert("#")
+        
+        guard let encodedUrlString = urlString.addingPercentEncoding(withAllowedCharacters: allowedCharacters),
               let url = URL(string: encodedUrlString) else {
             print("Invalid URL format")
             return


### PR DESCRIPTION
### 📌 개요
- 북마크 url에 # 그대로 처리

### 💻 작업 내용
- addingPercentEncoding의 allowed character에 "#" 추가 

### 🖼️ 스크린샷
||
|---|
|![Simulator Screen Recording - iPhone 15 Pro - 2024-04-24 at 15 19 41](https://github.com/42Box/iOS/assets/86519350/b9c89866-0d45-4ab1-84df-66a2adbd784f)|

