### PR TITLE
fix: 아이패드 대응 UIAlertConteollr preferredStyle 수정

### DIFF
--- a/iBox/Sources/BoxList/BoxListViewController.swift
+++ b/iBox/Sources/BoxList/BoxListViewController.swift
@@ -117,7 +117,7 @@ extension BoxListViewController: BoxListViewDelegate {
     }
     
     private func recheckDeleteFolder(at section: Int) {
-        let actionSheetController = UIAlertController(title: nil, message: "모든 북마크가 삭제됩니다.", preferredStyle: .actionSheet)
+        let actionSheetController = UIAlertController(title: nil, message: "모든 북마크가 삭제됩니다.", preferredStyle: .alert)
         let firstAction = UIAlertAction(title: "폴더 삭제", style: .destructive) {[weak self] _ in
             guard let contentView = self?.contentView as? BoxListView else { return }
             contentView.viewModel?.deleteFolderDirect(section)

--- a/iBox/Sources/BoxList/EditFolder/EditFolderViewController.swift
+++ b/iBox/Sources/BoxList/EditFolder/EditFolderViewController.swift
@@ -93,7 +93,7 @@ extension EditFolderViewController: EditFolderViewDelegate {
     }
     
     private func recheckDeleteFolder(at indexPath: IndexPath) {
-        let actionSheetController = UIAlertController(title: nil, message: "모든 북마크가 삭제됩니다.", preferredStyle: .actionSheet)
+        let actionSheetController = UIAlertController(title: nil, message: "모든 북마크가 삭제됩니다.", preferredStyle: .alert)
         let firstAction = UIAlertAction(title: "폴더 삭제", style: .destructive) {[weak self] _ in
             guard let contentView = self?.contentView as? EditFolderView else { return }
             contentView.viewModel?.deleteFolder(at: indexPath)


### PR DESCRIPTION
### 📌 개요
- 아이패드에서 UIAlertController를 present할 때 에러가 나는 문제를 해결합니다.

### 💻 작업 내용
- UIAlertController의 prefferedStyle을 .actionSheet에서 .alert로 변경했습니다.

### 🖼️ 스크린샷
|변경 전|변경 후|
|-|-|
|![IMG_7784](https://github.com/42Box/iOS/assets/116897060/e0f0c894-171b-4fd1-879d-9260cbf2444a)|![IMG_7785](https://github.com/42Box/iOS/assets/116897060/c1f7a904-1da8-4198-8130-eaa99a97b195)|
