### PR TITLE
fix: defaultFolders url이 없는 경우 폴더를 생성하지 않음.

### DIFF
--- a/iBox/Sources/Initializer/DefaultData.swift
+++ b/iBox/Sources/Initializer/DefaultData.swift
@@ -16,7 +16,9 @@ class DefaultData {
             fetchDefaultData { defaultFolders in
                 DispatchQueue.main.async {
                     CoreDataManager.shared.deleteAllFolders()
-                    CoreDataManager.shared.addInitialFolders(defaultFolders)
+                    if let defaultFolders = defaultFolders {
+                        CoreDataManager.shared.addInitialFolders(defaultFolders)
+                    }
                     UserDefaultsManager.isDefaultDataInserted = true
                     completion?()
                 }
@@ -26,7 +28,7 @@ class DefaultData {
         }
     }
     
-    static func fetchDefaultData(completion: @escaping ([Folder]) -> Void) {
+    static func fetchDefaultData(completion: @escaping ([Folder]?) -> Void) {
         let localDic: [String : String] = ["Seoul" : "default-kr", "default" : "default"]
         let cityName = "Seoul"
         let local = localDic[cityName] ?? "default"
@@ -35,20 +37,20 @@ class DefaultData {
         URLSession.shared.dataTask(with: url) { data, response, error in
             guard let data = data, error == nil else {
                 print("Error fetching default data: \(String(describing: error))")
-                completion(DefaultDataLoader.defaultData)
+                completion(nil)
                 return
             }
             
             do {
                 let folderData = try JSONDecoder().decode(FolderData.self, from: data)
-                let folders = [Folder(id: UUID(), name: "42 \(cityName)", bookmarks: folderData.list.map { Bookmark(id: UUID(), name: $0.name, url: URL(string: $0.url)!) })]
                 if let defaultURLData = URL(string: folderData.favorite) {
                     DefaultDataLoader.defaultURL = defaultURLData
                 }
+                let folders = [Folder(id: UUID(), name: "42 \(cityName)", bookmarks: folderData.list.map { Bookmark(id: UUID(), name: $0.name, url: URL(string: $0.url)!) })]
                 completion(folders)
             } catch {
                 print("Error decoding JSON: \(error)")
-                completion(DefaultDataLoader.defaultData)
+                completion(nil)
             }
         }.resume()
     }

--- a/iBox/Sources/Initializer/DefaultDataModel.swift
+++ b/iBox/Sources/Initializer/DefaultDataModel.swift
@@ -19,10 +19,10 @@ struct BookmarkData: Codable {
 }
 
 struct DefaultDataLoader {
-    static var defaultURL = URL(string: "https://github.com/42Box/iOS/blob/main/HowToUse.md#-how-to-use")!
-    static let defaultData = [
+    static var defaultURL = URL(string: "https://42box.github.io/iOSHowToUse/")!
+    static var defaultData: [Folder]? = [
         Folder(id: UUID(), name: "42Box", bookmarks: [
-            Bookmark(id: UUID(), name: "How to use 42Box", url: URL(string: "https://github.com/42Box/iOS/blob/main/HowToUse.md#-how-to-use")!),
+            Bookmark(id: UUID(), name: "How to use 42Box", url: URL(string: "https://42box.github.io/iOSHowToUse/")!),
 //            Bookmark(id: UUID(), name: "42 Intra", url: URL(string: "https://profile.intra.42.fr/")!),
 //            Bookmark(id: UUID(), name: "42Where", url: URL(string: "https://www.where42.kr/")! ),
 //            Bookmark(id: UUID(), name: "42Stat", url: URL(string: "https://stat.42seoul.kr/")!),

--- a/iBox/Sources/Settings/Reset/ResetViewController.swift
+++ b/iBox/Sources/Settings/Reset/ResetViewController.swift
@@ -36,14 +36,14 @@ class ResetViewController: BaseViewController<ResetView>, BaseViewControllerProt
 extension ResetViewController: ResetViewDelegate {
     
     func showAlert() {
-        let alertController = UIAlertController(title: "경고", message: "이 작업은 되돌릴 수 없습니다. 계속하려면 \"iBox\"라고 입력해 주세요.", preferredStyle: .alert)
+        let alertController = UIAlertController(title: "경고", message: "이 작업은 되돌릴 수 없습니다. 계속하려면 \"42Box\"라고 입력해 주세요.", preferredStyle: .alert)
         
         let cancelAction = UIAlertAction(title: "취소", style: .cancel, handler: nil)
         alertController.addAction(cancelAction)
         
         let confirmAction = UIAlertAction(title: "확인", style: .default) { [weak self] _ in
             guard let self = self else { return }
-            if let textField = alertController.textFields?.first, let text = textField.text, text == "iBox" {
+            if let textField = alertController.textFields?.first, let text = textField.text, text == "42Box" {
                 self.resetData()
             } else {
                 self.showAlert()
@@ -58,7 +58,7 @@ extension ResetViewController: ResetViewDelegate {
         alertController.addTextField() { textField in
             NotificationCenter.default.addObserver(forName: UITextField.textDidChangeNotification, object: textField, queue: OperationQueue.main, using:
                                                     {_ in
-                let isTextMatch = textField.text?.trimmingCharacters(in: .whitespacesAndNewlines) == "iBox"
+                let isTextMatch = textField.text?.trimmingCharacters(in: .whitespacesAndNewlines) == "42Box"
                 
                 confirmAction.isEnabled = isTextMatch
             })


### PR DESCRIPTION
### 📌 개요
- defaultFolders url이 없는 경우 폴더를 생성하지 않음.
- https://42box.github.io/iOSHowToUse/ 로 how to use 를 변경하고 favorite view에 적용시켰습니다.

### 💻 작업 내용
- DefaultDataLoader.defaultURL
- DefaultDataLoader.defaultData

### 🖼️ 스크린샷
||
|---|
|![image](https://github.com/42Box/iOS/assets/85754295/5be2dbb4-1266-4d2f-ae3c-68ac62ea0c68)|
