### PR TITLE
fix: 아이패드 대응 UIActivityViewController popover 설정

### DIFF
--- a/iBox/Sources/BoxList/BoxListView.swift
+++ b/iBox/Sources/BoxList/BoxListView.swift
@@ -448,10 +448,7 @@ extension BoxListView: UITableViewDelegate {
                 generator.impactOccurred()
             }
             
-            let activityViewController = UIActivityViewController(activityItems: [url], applicationActivities: nil)
-            if let viewController = self.delegate as? UIViewController {
-                viewController.present(activityViewController, animated: true, completion: nil)
-            }
+            delegate?.pushViewController(url: url)
         }
         
         let editAction = UIAction(title: "북마크 편집", image: UIImage(systemName: "pencil")) { [weak self] action in
@@ -474,8 +471,6 @@ extension BoxListView: UITableViewDelegate {
                 generator.impactOccurred()
             }
         }
-        
-        
         
         return UIMenu(title: "", children: [favoriteAction, shareAction, editAction, deleteAction])
     }

--- a/iBox/Sources/BoxList/BoxListViewController.swift
+++ b/iBox/Sources/BoxList/BoxListViewController.swift
@@ -265,6 +265,14 @@ extension BoxListViewController: BoxListViewDelegate {
     func pushViewController(url: URL?) {
         guard let url = url else { return }
         let activityViewController = UIActivityViewController(activityItems: [url], applicationActivities: nil)
+        
+        // 아이패드 대응
+        if let popoverController = activityViewController.popoverPresentationController {
+            popoverController.sourceView = self.view
+            popoverController.sourceRect = CGRect(x: self.view.bounds.midX, y: self.view.bounds.midY, width: 0, height: 0)
+            popoverController.permittedArrowDirections = []
+        }
+        
         self.present(activityViewController, animated: true)
     }
     


### PR DESCRIPTION
### 📌 개요
- 아이패드에서 공유 기능이 작동하지 않는 문제를 해결합니다.

### 💻 작업 내용
- popover가 표시될 위치(`sourceView`, `sourceRect`)를 지정합니다.

### 🖼️ 스크린샷
![IMG_0013](https://github.com/42Box/iOS/assets/116897060/46ccc6ca-0f1e-4b85-a51f-29f080c3ac3d)

